### PR TITLE
Route progress values through UserData

### DIFF
--- a/Scripts/BrickBlast/Data/ResourceObject.cs
+++ b/Scripts/BrickBlast/Data/ResourceObject.cs
@@ -13,6 +13,7 @@
 using System;
 using System.Threading.Tasks;
 using UnityEngine;
+using Ray.Services;
 
 namespace BlockPuzzleGameToolkit.Scripts.Data
 {
@@ -22,6 +23,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Data
 
         //name of the resource
         private string ResourceName => name;
+        private bool IsCoins => ResourceName == "Coins";
 
         public abstract int DefaultValue { get; }
 
@@ -55,6 +57,11 @@ namespace BlockPuzzleGameToolkit.Scripts.Data
 
         public int LoadResource()
         {
+            if (IsCoins)
+            {
+                return Database.UserData?.Coins ?? DefaultValue;
+            }
+
             return PlayerPrefs.GetInt(ResourceName, DefaultValue);
         }
 
@@ -62,7 +69,18 @@ namespace BlockPuzzleGameToolkit.Scripts.Data
         public void Add(int amount)
         {
             Resource += amount;
-            PlayerPrefs.SetInt(ResourceName, Resource);
+            if (IsCoins)
+            {
+                if (Database.UserData != null)
+                {
+                    Database.UserData.Coins = Resource;
+                    Database.Instance?.Save(Database.UserData);
+                }
+            }
+            else
+            {
+                PlayerPrefs.SetInt(ResourceName, Resource);
+            }
             OnResourceChanged();
         }
 
@@ -70,8 +88,19 @@ namespace BlockPuzzleGameToolkit.Scripts.Data
         public void Set(int amount)
         {
             Resource = amount;
-            PlayerPrefs.SetInt(ResourceName, Resource);
-            PlayerPrefs.Save();
+            if (IsCoins)
+            {
+                if (Database.UserData != null)
+                {
+                    Database.UserData.Coins = Resource;
+                    Database.Instance?.Save(Database.UserData);
+                }
+            }
+            else
+            {
+                PlayerPrefs.SetInt(ResourceName, Resource);
+                PlayerPrefs.Save();
+            }
             OnResourceChanged();
         }
 
@@ -81,8 +110,19 @@ namespace BlockPuzzleGameToolkit.Scripts.Data
             if (IsEnough(amount))
             {
                 Resource -= amount;
-                PlayerPrefs.SetInt(ResourceName, Resource);
-                PlayerPrefs.Save();
+                if (IsCoins)
+                {
+                    if (Database.UserData != null)
+                    {
+                        Database.UserData.Coins = Resource;
+                        Database.Instance?.Save(Database.UserData);
+                    }
+                }
+                else
+                {
+                    PlayerPrefs.SetInt(ResourceName, Resource);
+                    PlayerPrefs.Save();
+                }
                 OnResourceChanged();
                 return true;
             }

--- a/Scripts/BrickBlast/GUI/Labels/ResourceLabel.cs
+++ b/Scripts/BrickBlast/GUI/Labels/ResourceLabel.cs
@@ -25,13 +25,28 @@ namespace BlockPuzzleGameToolkit.Scripts.GUI.Labels
 
         protected virtual void OnEnable()
         {
-            resourceObject.OnResourceUpdate += UpdateValue;
-            UpdateValue(resourceObject.GetValue());
+            if (resourceObject != null && resourceObject.name == "Coins")
+            {
+                Ray.Services.Database.UserData.CoinsChanged += UpdateValue;
+                UpdateValue(Ray.Services.Database.UserData.Coins);
+            }
+            else
+            {
+                resourceObject.OnResourceUpdate += UpdateValue;
+                UpdateValue(resourceObject.GetValue());
+            }
         }
 
         protected virtual void OnDisable()
         {
-            resourceObject.OnResourceUpdate -= UpdateValue;
+            if (resourceObject != null && resourceObject.name == "Coins")
+            {
+                Ray.Services.Database.UserData.CoinsChanged -= UpdateValue;
+            }
+            else
+            {
+                resourceObject.OnResourceUpdate -= UpdateValue;
+            }
         }
 
         protected virtual void UpdateValue(int count)

--- a/Scripts/BrickBlast/Popups/CoinsShop.cs
+++ b/Scripts/BrickBlast/Popups/CoinsShop.cs
@@ -12,7 +12,6 @@
 
 using System.Linq;
 using BlockPuzzleGameToolkit.Scripts.Audio;
-using BlockPuzzleGameToolkit.Scripts.Data;
 using BlockPuzzleGameToolkit.Scripts.GUI.Labels;
 using BlockPuzzleGameToolkit.Scripts.Services.IAP;
 using BlockPuzzleGameToolkit.Scripts.Settings;
@@ -70,7 +69,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
             var count = shopItem.settingsShopItem.Value;
             LabelAnim.AnimateForResource(shopItem.resource, shopItem.BuyItemButton.transform.position, "+" + count, SoundBase.instance.coins, () =>
             {
-                ResourceManager.instance.GetResource("Coins").Add(count);
+                Ray.Services.Database.UserData.AddCoins(count);
                 GetComponentInParent<Popup>().CloseDelay();
             });
 
@@ -102,10 +101,9 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
         public void AwawrdCoins()
         {
             var coins = GameManager.instance.GameSettings.coinsForAd;
-            var resourceObject = ResourceManager.instance.GetResource("Coins");
-            LabelAnim.AnimateForResource(resourceObject, watchAd.BuyItemButton.transform.position, "+" + coins, SoundBase.instance.coins, () =>
+            LabelAnim.AnimateForResource(watchAd.resource, watchAd.BuyItemButton.transform.position, "+" + coins, SoundBase.instance.coins, () =>
             {
-                resourceObject.Add(coins);
+                Ray.Services.Database.UserData.AddCoins(coins);
                 GetComponentInParent<Popup>().Close();
             });
         }

--- a/Scripts/BrickBlast/Popups/LuckySpin.cs
+++ b/Scripts/BrickBlast/Popups/LuckySpin.cs
@@ -14,7 +14,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using BlockPuzzleGameToolkit.Scripts.Audio;
-using BlockPuzzleGameToolkit.Scripts.Data;
 using BlockPuzzleGameToolkit.Scripts.GUI;
 using BlockPuzzleGameToolkit.Scripts.Popups.Reward;
 using BlockPuzzleGameToolkit.Scripts.Settings;
@@ -138,10 +137,15 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
 
         private void BuySpin()
         {
-            if (ResourceManager.instance.Consume("Coins", spinSettings.costToSpin))
+            var data = Ray.Services.Database.UserData;
+            if (data.SpendCoins(spinSettings.costToSpin))
             {
                 ShowCoinsSpendFX(buySpinButton.transform.position);
                 Spin();
+            }
+            else
+            {
+                MenuManager.instance.ShowPopup<CoinsShop>();
             }
         }
 

--- a/Scripts/BrickBlast/Popups/MainMenu.cs
+++ b/Scripts/BrickBlast/Popups/MainMenu.cs
@@ -47,7 +47,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
             settingsButton.onClick.AddListener(SettingsButtonClicked);
             luckySpin.onClick.AddListener(LuckySpinButtonClicked);
             UpdateFreeSpinMarker();
-            GameDataManager.LevelNum = PlayerPrefs.GetInt("Level", 1);
+            GameDataManager.LevelNum = Ray.Services.Database.UserData.Level;
             var levelsCount = Resources.LoadAll<Level>("Levels").Length;
             luckySpin.gameObject.SetActive(GameManager.instance.GameSettings.enableLuckySpin);
             if(!GameManager.instance.GameSettings.enableTimedMode)

--- a/Scripts/BrickBlast/Popups/PreFailed.cs
+++ b/Scripts/BrickBlast/Popups/PreFailed.cs
@@ -11,7 +11,6 @@
 // // THE SOFTWARE.
 
 using BlockPuzzleGameToolkit.Scripts.Audio;
-using BlockPuzzleGameToolkit.Scripts.Data;
 using BlockPuzzleGameToolkit.Scripts.Enums;
 using BlockPuzzleGameToolkit.Scripts.GUI;
 using BlockPuzzleGameToolkit.Scripts.System;
@@ -93,17 +92,21 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
                 return;
             }
 
-            var coinsResource = ResourceManager.instance.GetResource("Coins");
-            if (coinsResource.Consume(price))
+            var data = Ray.Services.Database.UserData;
+            if (data.SpendCoins(price))
             {
                 hasContinued = true;
                 continueButton.interactable = false;
                 rewardButton.interactable = false;
-                                
+
                 CancelInvoke(nameof(UpdateTimer));
                 ShowCoinsSpendFX(continueButton.transform.position);
                 StopInteration();
                 OnContinue();
+            }
+            else
+            {
+                MenuManager.instance.ShowPopup<CoinsShop>();
             }
         }
 

--- a/Scripts/BrickBlast/System/GameDataManager.cs
+++ b/Scripts/BrickBlast/System/GameDataManager.cs
@@ -16,6 +16,7 @@ using BlockPuzzleGameToolkit.Scripts.Enums;
 using BlockPuzzleGameToolkit.Scripts.LevelsData;
 using UnityEditor;
 using UnityEngine;
+using Ray.Services;
 
 namespace BlockPuzzleGameToolkit.Scripts.System
 {
@@ -29,8 +30,7 @@ namespace BlockPuzzleGameToolkit.Scripts.System
 
         public static void ClearPlayerProgress()
         {
-            PlayerPrefs.DeleteKey("Level");
-            PlayerPrefs.Save();
+            Database.UserData.SetLevel(1);
         }
 
         public static void ClearALlData()
@@ -44,27 +44,26 @@ namespace BlockPuzzleGameToolkit.Scripts.System
             }
 
             AssetDatabase.SaveAssets();
-
             PlayerPrefs.DeleteAll();
             PlayerPrefs.DeleteAll();
             PlayerPrefs.Save();
+            Database.UserData.SetLevel(1);
             #endif
         }
 
         public static void UnlockLevel(int currentLevel)
         {
-            int savedLevel = PlayerPrefs.GetInt("Level", 1);
+            int savedLevel = Database.UserData.Level;
             if (savedLevel < currentLevel)
             {
                 LevelNum = currentLevel;
-                PlayerPrefs.SetInt("Level", currentLevel);
-                PlayerPrefs.Save();
+                Database.UserData.SetLevel(currentLevel);
             }
         }
 
         public static int GetLevelNum()
         {
-            return PlayerPrefs.GetInt("Level", 1);
+            return Database.UserData.Level;
         }
 
         public static Level GetLevel()
@@ -102,8 +101,7 @@ namespace BlockPuzzleGameToolkit.Scripts.System
         public static void SetAllLevelsCompleted()
         {
             var levels = Resources.LoadAll<Level>("Levels").Length;
-            PlayerPrefs.SetInt("Level", levels);
-            PlayerPrefs.Save();
+            Database.UserData.SetLevel(levels);
         }
 
         internal static bool HasMoreLevels()
@@ -116,6 +114,7 @@ namespace BlockPuzzleGameToolkit.Scripts.System
         public static void SetLevelNum(int stateCurrentLevel)
         {
             LevelNum = stateCurrentLevel;
+            Database.UserData.SetLevel(stateCurrentLevel);
         }
     }
 }


### PR DESCRIPTION
## Summary
- centralize coins and level tracking in `UserData`
- migrate legacy PlayerPrefs data into new `UserData` fields
- replace direct PlayerPrefs/resource manager calls with `UserData` access and events

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `rg -n 'PlayerPrefs.*Coins' -g '*.cs'`
- `rg -n 'PlayerPrefs.*Level' -g '*.cs'`

------
https://chatgpt.com/codex/tasks/task_b_689850592dd8832d80fa2c8c60082f11