### PR TITLE
Initialize Tenjin earlier to avoid cheat event crash

### DIFF
--- a/Services/ApplicationService.cs
+++ b/Services/ApplicationService.cs
@@ -34,12 +34,11 @@ namespace Ray.Services
             await ConnectionService.Instance.WaitForConnection();
             _rayDebug.Log("Single Code Entry - Connection Established", this);
 
-            await Database.Instance.Initialize();
-            _rayDebug.Log("Single Code Entry - Database Initialized", this);
-
-
             TenjinService.Instance.Initialize();
             _rayDebug.Log("Single Code Entry - TenjinService Initialized", this);
+
+            await Database.Instance.Initialize();
+            _rayDebug.Log("Single Code Entry - Database Initialized", this);
 
 #if UNITY_ANDROID
             //await CMPService.Instance.Initialize();

--- a/Services/TenjinService.cs
+++ b/Services/TenjinService.cs
@@ -117,6 +117,12 @@ namespace Ray.Services
 
         public void SendCheatEvent(string fieldKey, string oldValue, string newValue)
         {
+            if (_baseTenjin == null)
+            {
+                _rayDebug.LogWarning("TenjinService not initialized; cheat event not sent", this);
+                return;
+            }
+
             _baseTenjin.SendEvent($"Cheated_{fieldKey}", newValue);
         }
 


### PR DESCRIPTION
## Summary
- Initialize TenjinService before loading database so cheat detection can report events safely
- Guard SendCheatEvent against null Tenjin instance and warn when not initialized

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_6898576fdd5c832dacc2b40bcb9805d1