### PR TITLE
Initialize new users with default power stats

### DIFF
--- a/Scripts/MyCode/Database/Database.cs
+++ b/Scripts/MyCode/Database/Database.cs
@@ -226,8 +226,12 @@ namespace Ray.Services
                 if (defaultSnapshot.Exists)
                 {
                     Dictionary<string, object> defaultData = defaultSnapshot.ToDictionary();
-                    int defaultReachLevel = defaultData.ContainsKey("ReachLevel") ? Convert.ToInt32(defaultData["ReachLevel"]) : 0;
+                    int defaultLevel = defaultData.ContainsKey("Level") ? Convert.ToInt32(defaultData["Level"]) : 1;
+                    int defaultReachLevel = defaultData.ContainsKey("ReachLevel") ? Convert.ToInt32(defaultData["ReachLevel"]) : defaultLevel;
                     int defaultSpaceLevel = defaultData.ContainsKey("SpaceLevel") ? Convert.ToInt32(defaultData["SpaceLevel"]) : 0;
+                    int defaultPower1 = defaultData.ContainsKey("Power_1") ? Convert.ToInt32(defaultData["Power_1"]) : 0;
+                    int defaultPower2 = defaultData.ContainsKey("Power_2") ? Convert.ToInt32(defaultData["Power_2"]) : 0;
+                    int defaultPower3 = defaultData.ContainsKey("Power_3") ? Convert.ToInt32(defaultData["Power_3"]) : 0;
 
                     Timestamp currentTime = await TimeApiService.Instance.GetCurrentTime();
 
@@ -243,8 +247,13 @@ namespace Ray.Services
                         Stats = new UserData.StatsData
                         {
                             ReachLevel = defaultReachLevel,
-                            SpaceLevel = defaultSpaceLevel
-                        }
+                            SpaceLevel = defaultSpaceLevel,
+                            Power_1 = defaultPower1,
+                            Power_2 = defaultPower2,
+                            Power_3 = defaultPower3
+                        },
+
+                        Level = defaultLevel
                     };
 
                     // Save new user data to Firestore

--- a/Scripts/MyCode/Database/UserData.cs
+++ b/Scripts/MyCode/Database/UserData.cs
@@ -74,6 +74,9 @@ public class UserData
         [FirestoreProperty] public int RvCount { get; set; } = 0;
         [FirestoreProperty] public int HighestReachEvent { get; set; } = 0;
         [FirestoreProperty] public int TotalSessions { get; set; } = 0;
+        [FirestoreProperty] public int Power_1 { get; set; } = 0;
+        [FirestoreProperty] public int Power_2 { get; set; } = 0;
+        [FirestoreProperty] public int Power_3 { get; set; } = 0;
     }
 
     [FirestoreData]


### PR DESCRIPTION
## Summary
- Load default level and power stats from Firebase when creating user data
- Store Power_1, Power_2, and Power_3 in UserData stats

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68985b7517d8832d95047afbb33c3882