### PR TITLE
Add booster shop UI handling

### DIFF
--- a/Scripts/MyCode/Controllers/UIController.cs
+++ b/Scripts/MyCode/Controllers/UIController.cs
@@ -52,6 +52,7 @@ namespace Ray.Controllers
             EventService.Application.OnGameContentStart += TryOfferFreeGift;
 
             EventService.Resource.OnMenuResourceChanged += RefreshCurrencies;
+            EventService.Resource.OnMenuResourceChanged += RefreshShop;
 
             EventService.UI.OnToggleSound += ToggleSoundSprite;
             EventService.UI.OnToggleTutorial += ToggleTutorial;
@@ -113,6 +114,7 @@ namespace Ray.Controllers
             EventService.Application.OnGameContentStart -= TryOfferFreeGift;
 
             EventService.Resource.OnMenuResourceChanged -= RefreshCurrencies;
+            EventService.Resource.OnMenuResourceChanged -= RefreshShop;
 
             EventService.UI.OnToggleSound -= ToggleSoundSprite;
             EventService.UI.OnToggleTutorial -= ToggleTutorial;
@@ -321,11 +323,28 @@ namespace Ray.Controllers
 
             _view.PulseCurrency(_element.Shop.ShopCurrency, Database.UserData.Stats.TotalCurrency);
 
+            var brick = RayBrickMediator.Instance;
+            if (brick != null)
+            {
+                _view.PulseCurrency(brick.Shop.Currency, Database.UserData.Stats.TotalCurrency);
+                RefreshBoosterItem(brick.Shop.ClearRow, Database.UserData.Stats.Power_1);
+                RefreshBoosterItem(brick.Shop.ClearColumn, Database.UserData.Stats.Power_2);
+                RefreshBoosterItem(brick.Shop.ClearSquare, Database.UserData.Stats.Power_3);
+            }
+
             if (IAPService.Instance.IsSubsribed(Database.GameSettings.InAppPurchases.SubscriptionNoAds))
             {
                 _view.Hide(_element.Shop.CtnrSubscriptionNoAds);
             }
             else _view.Show(_element.Shop.CtnrSubscriptionNoAds);
+        }
+
+        private void RefreshBoosterItem(RayBrickMediator.BoosterItem item, int amount)
+        {
+            _view.SetText(item.Amount, amount);
+            _view.SetText(item.Cost, item.Price);
+            bool canBuy = Database.UserData.Stats.TotalCurrency >= item.Price && amount < 99;
+            _view.ButtonInteractableState(canBuy, item.BtnPurchase);
         }
 
         // Features

--- a/Scripts/MyCode/Events/EventService.cs
+++ b/Scripts/MyCode/Events/EventService.cs
@@ -5,6 +5,11 @@ namespace Ray.Services
 {
     public class EventService : MonoBehaviour
     {
+        private void Awake()
+        {
+            DontDestroyOnLoad(gameObject);
+        }
+
         public static readonly ApplicationEvent Application = new ApplicationEvent();
         public static readonly UIEvent UI = new UIEvent();
         public static readonly LevelEvent Level = new LevelEvent();
@@ -35,6 +40,8 @@ namespace Ray.Services
             public UnityAction<Component> OnToggleInsufficient;
             public UnityAction<Component> OnToggleDataMismatch;
             public UnityAction<Component> OnToggleShop;
+
+            public UnityAction<Component, BoosterType, int> OnBoosterPurchaseBtn;
 
             public UnityAction<Component, string> OnIAPPurchaseBtn;
 

--- a/Scripts/MyCode/Mediators/RayBrickMediator.cs
+++ b/Scripts/MyCode/Mediators/RayBrickMediator.cs
@@ -1,0 +1,38 @@
+using TMPro;
+using UnityEngine;
+
+public class RayBrickMediator : MonoBehaviour
+{
+    public static RayBrickMediator Instance { get; private set; }
+
+    private void Awake()
+    {
+        Instance = this;
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this) Instance = null;
+    }
+
+    [System.Serializable]
+    public class BoosterItem
+    {
+        public TextMeshProUGUI Amount;
+        public TextMeshProUGUI Cost;
+        public GameObject BtnPurchase;
+        public int Price;
+    }
+
+    [System.Serializable]
+    public class BoosterShopElements
+    {
+        public TextMeshProUGUI Currency;
+        public BoosterItem ClearRow;
+        public BoosterItem ClearColumn;
+        public BoosterItem ClearSquare;
+    }
+
+    [Header("Booster Shop")]
+    public BoosterShopElements Shop = new BoosterShopElements();
+}

--- a/Scripts/MyCode/Mediators/RayBrickMediator.cs.meta
+++ b/Scripts/MyCode/Mediators/RayBrickMediator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 81e52aba937c43daa34b13b2f6c43112

--- a/Scripts/MyCode/Mediators/UIEventMediator.cs
+++ b/Scripts/MyCode/Mediators/UIEventMediator.cs
@@ -3,6 +3,11 @@ using UnityEngine;
 
 public class UIEventMediator : MonoBehaviour
 {
+    private void Awake()
+    {
+        DontDestroyOnLoad(gameObject);
+    }
+
     // Application Open
     public void _OnUpdateApplicationBtn() => EventService.UI.OnUpdateApplicationBtn.Invoke(this);
 
@@ -16,6 +21,10 @@ public class UIEventMediator : MonoBehaviour
     public void _OnToggleInsufficientBtn() => EventService.UI.OnToggleInsufficient.Invoke(this);
     public void _OnToggleDataMismatchBtn() => EventService.UI.OnToggleDataMismatch.Invoke(this);
     public void _OnToggleShop() => EventService.UI.OnToggleShop.Invoke(this);
+
+    public void _OnBuyClearRow(int cost) => EventService.UI.OnBoosterPurchaseBtn.Invoke(this, BoosterType.ClearRow, cost);
+    public void _OnBuyClearColumn(int cost) => EventService.UI.OnBoosterPurchaseBtn.Invoke(this, BoosterType.ClearColumn, cost);
+    public void _OnBuyClearSquare(int cost) => EventService.UI.OnBoosterPurchaseBtn.Invoke(this, BoosterType.ClearSquare, cost);
 
     // Rewarded
     public void _OnPenaltyBtn() => EventService.UI.OnRewardedBtn.Invoke(this, RewardedType.Penalty);

--- a/Scripts/MyCode/Services/BoosterType.cs
+++ b/Scripts/MyCode/Services/BoosterType.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Ray.Services
+{
+    public enum BoosterType
+    {
+        ClearRow,
+        ClearColumn,
+        ClearSquare
+    }
+}

--- a/Scripts/MyCode/Services/BoosterType.cs.meta
+++ b/Scripts/MyCode/Services/BoosterType.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 14e1c84c215e4ff7864477758100e999


### PR DESCRIPTION
## Summary
- keep event and UI mediators across scene loads
- expose booster shop mediator via static instance for safe lookup
- update UI controller to locate mediator at runtime and refresh after currency changes

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68987140afd4832dad726d70d857b9a0