### PR TITLE
Guard shop refresh from null brick mediator

### DIFF
--- a/Scripts/MyCode/Controllers/UIController.cs
+++ b/Scripts/MyCode/Controllers/UIController.cs
@@ -17,7 +17,6 @@ namespace Ray.Controllers
 
         [Header("Configs")]
         [SerializeField, RequireReference] private UIElementMediator _element;
-        [SerializeField, RequireReference] private RayBrickMediator _brick;
 
         [Header("References")]
         [SerializeField, RequireReference] UIView _view;
@@ -323,7 +322,7 @@ namespace Ray.Controllers
             _rayDebug.Event("RefreshShop", c, this);
 
             _view.PulseCurrency(_element.Shop.ShopCurrency, Database.UserData.Stats.TotalCurrency);
-            
+
             var brick = RayBrickMediator.Instance;
             if (brick != null)
             {
@@ -333,11 +332,6 @@ namespace Ray.Controllers
                 RefreshBoosterItem(brick.Shop.ClearSquare, Database.UserData.Stats.Power_3);
             }
 
-
-//            _view.PulseCurrency(_brick.Shop.Currency, Database.UserData.Stats.TotalCurrency);
-            RefreshBoosterItem(_brick.Shop.ClearRow, Database.UserData.Stats.Power_1);
-            RefreshBoosterItem(_brick.Shop.ClearColumn, Database.UserData.Stats.Power_2);
-            RefreshBoosterItem(_brick.Shop.ClearSquare, Database.UserData.Stats.Power_3);
             if (IAPService.Instance.IsSubsribed(Database.GameSettings.InAppPurchases.SubscriptionNoAds))
             {
                 _view.Hide(_element.Shop.CtnrSubscriptionNoAds);


### PR DESCRIPTION
## Summary
- Avoid null references by checking for `RayBrickMediator` before refreshing booster items
- Remove unused serialized brick mediator reference

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6898865d701c832d81ea3346cb9b9f27