### PR TITLE
Add delete row booster

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Boosters.cs
+++ b/Scripts/BrickBlast/Gameplay/Boosters.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace BlockPuzzleGameToolkit.Scripts.Gameplay
+{
+    public class Boosters : MonoBehaviour
+    {
+        [SerializeField] private RectTransform rowVisualPrefab;
+
+        private RectTransform rowVisual;
+        private bool deleteRowMode;
+        private FieldManager fieldManager;
+        private LevelManager levelManager;
+
+        private void Awake()
+        {
+            fieldManager = FindObjectOfType<FieldManager>();
+            levelManager = FindObjectOfType<LevelManager>();
+        }
+
+        private void Update()
+        {
+            if (Keyboard.current != null && Keyboard.current.jKey.wasPressedThisFrame)
+            {
+                ToggleDeleteRow();
+            }
+
+            if (!deleteRowMode || fieldManager == null || levelManager == null)
+            {
+                return;
+            }
+
+            Vector2 pointer = Mouse.current != null ? Mouse.current.position.ReadValue() : Vector2.zero;
+            if (RectTransformUtility.ScreenPointToLocalPointInRectangle(fieldManager.field, pointer, null, out var local))
+            {
+                if (rowVisual == null)
+                {
+                    if (rowVisualPrefab == null)
+                    {
+                        return;
+                    }
+                    rowVisual = Instantiate(rowVisualPrefab, fieldManager.field);
+                }
+
+                rowVisual.gameObject.SetActive(true);
+
+                float cellSize = fieldManager.GetCellSize();
+                int rowIndex = Mathf.Clamp(Mathf.FloorToInt(local.y / cellSize), 0, fieldManager.cells.GetLength(0) - 1);
+
+                rowVisual.anchoredPosition = new Vector2(0, rowIndex * cellSize);
+                rowVisual.sizeDelta = new Vector2(fieldManager.field.rect.width, cellSize);
+
+                if (Mouse.current != null && Mouse.current.leftButton.wasPressedThisFrame)
+                {
+                    ApplyDeleteRow(rowIndex);
+                }
+            }
+            else if (rowVisual != null)
+            {
+                rowVisual.gameObject.SetActive(false);
+            }
+        }
+
+        private void ToggleDeleteRow()
+        {
+            deleteRowMode = !deleteRowMode;
+            if (!deleteRowMode && rowVisual != null)
+            {
+                rowVisual.gameObject.SetActive(false);
+            }
+        }
+
+        private void ApplyDeleteRow(int row)
+        {
+            deleteRowMode = false;
+            if (rowVisual != null)
+            {
+                rowVisual.gameObject.SetActive(false);
+            }
+
+            var cells = new List<Cell>();
+            for (int x = 0; x < fieldManager.cells.GetLength(1); x++)
+            {
+                cells.Add(fieldManager.cells[row, x]);
+            }
+
+            StartCoroutine(levelManager.DestroyLines(new List<List<Cell>> { cells }, null));
+
+            int score = GameManager.instance.GameSettings.ScorePerLine;
+            levelManager.OnScored?.Invoke(score);
+        }
+    }
+}

--- a/Scripts/BrickBlast/Gameplay/Boosters.cs.meta
+++ b/Scripts/BrickBlast/Gameplay/Boosters.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e591838abae40bfbdf5915ab2686356
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -551,7 +551,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             }
         }
 
-        private IEnumerator DestroyLines(List<List<Cell>> lines, Shape shape)
+        public IEnumerator DestroyLines(List<List<Cell>> lines, Shape shape)
         {
             SoundBase.instance.PlayLimitSound(SoundBase.instance.combo[Mathf.Min(comboCounter, SoundBase.instance.combo.Length - 1)]);
             EventManager.GetEvent<Shape>(EGameEvent.LineDestroyed).Invoke(shape);
@@ -583,7 +583,18 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 
         private Color GetExplosionColor(Shape shape)
         {
-            var itemTemplateTopColor = shape.GetActiveItems()[0].itemTemplate.overlayColor;
+            if (shape == null)
+            {
+                return Color.white;
+            }
+
+            var items = shape.GetActiveItems();
+            if (items == null || items.Count == 0)
+            {
+                return Color.white;
+            }
+
+            var itemTemplateTopColor = items[0].itemTemplate.overlayColor;
             if (_levelData.levelType.singleColorMode)
             {
                 itemTemplateTopColor = itemFactory.GetOneColor().overlayColor;


### PR DESCRIPTION
## Summary
- add `Boosters` script enabling delete-row power-up when player presses `j`
- expose `LevelManager.DestroyLines` and handle null shapes for booster use

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68988efa5b44832d82acccd39a480a85