### PR TITLE
Add delete row booster

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Boosters.cs
+++ b/Scripts/BrickBlast/Gameplay/Boosters.cs
@@ -1,0 +1,131 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace BlockPuzzleGameToolkit.Scripts.Gameplay
+{
+    public class Boosters : MonoBehaviour
+    {
+        [SerializeField] private RectTransform rowVisualPrefab;
+
+        private RectTransform rowVisual;
+        private bool deleteRowMode;
+        private FieldManager fieldManager;
+        private LevelManager levelManager;
+
+        private void Awake()
+        {
+            fieldManager = FindObjectOfType<FieldManager>();
+            levelManager = FindObjectOfType<LevelManager>();
+        }
+
+        private void Update()
+        {
+            if (Keyboard.current != null && Keyboard.current.jKey.wasPressedThisFrame)
+            {
+                Debug.Log("[Codex] J key pressed");
+                ToggleDeleteRow();
+            }
+
+            if (!deleteRowMode || fieldManager == null || levelManager == null)
+            {
+                Debug.Log("[Codex] Booster inactive or managers missing");
+                return;
+            }
+
+            Vector2 pointer = Mouse.current != null ? Mouse.current.position.ReadValue() : Vector2.zero;
+            if (RectTransformUtility.ScreenPointToLocalPointInRectangle(fieldManager.field, pointer, null, out var local))
+            {
+                Debug.Log("[Codex] Pointer inside field");
+                if (rowVisual == null)
+                {
+                    if (rowVisualPrefab != null)
+                    {
+                        rowVisual = Instantiate(rowVisualPrefab, fieldManager.field);
+                        Debug.Log("[Codex] Row visual instantiated from prefab");
+                    }
+                    else
+                    {
+                        Debug.Log("[Codex] No prefab provided, creating default row visual");
+                        rowVisual = CreateDefaultRowVisual();
+                    }
+                }
+
+                rowVisual.gameObject.SetActive(true);
+
+                float cellSize = fieldManager.GetCellSize();
+                float pivotOffset = fieldManager.field.rect.height * fieldManager.field.pivot.y;
+                int rowIndex = Mathf.Clamp(
+                    Mathf.FloorToInt((local.y + pivotOffset) / cellSize),
+                    0,
+                    fieldManager.cells.GetLength(0) - 1);
+                Debug.Log($"[Codex] Hovering row {rowIndex}");
+
+                float yPos = rowIndex * cellSize - pivotOffset;
+                rowVisual.anchoredPosition = new Vector2(0, yPos);
+                rowVisual.sizeDelta = new Vector2(fieldManager.field.rect.width, cellSize);
+
+                if (Mouse.current != null && Mouse.current.leftButton.wasPressedThisFrame)
+                {
+                    Debug.Log($"[Codex] Deleting row {rowIndex}");
+                    ApplyDeleteRow(rowIndex);
+                }
+            }
+            else
+            {
+                if (rowVisual != null)
+                {
+                    rowVisual.gameObject.SetActive(false);
+                }
+                Debug.Log("[Codex] Pointer outside field");
+            }
+        }
+
+        private void ToggleDeleteRow()
+        {
+            deleteRowMode = !deleteRowMode;
+            Debug.Log($"[Codex] Delete row mode {(deleteRowMode ? "enabled" : "disabled")}");
+            if (!deleteRowMode && rowVisual != null)
+            {
+                rowVisual.gameObject.SetActive(false);
+            }
+        }
+
+        private void ApplyDeleteRow(int row)
+        {
+            deleteRowMode = false;
+            if (rowVisual != null)
+            {
+                rowVisual.gameObject.SetActive(false);
+            }
+
+            Debug.Log($"[Codex] ApplyDeleteRow called for row {row}");
+
+            var cells = new List<Cell>();
+            for (int x = 0; x < fieldManager.cells.GetLength(1); x++)
+            {
+                cells.Add(fieldManager.cells[row, x]);
+            }
+
+            StartCoroutine(levelManager.DestroyLines(new List<List<Cell>> { cells }, null));
+            Debug.Log("[Codex] DestroyLines coroutine started");
+
+            int score = GameManager.instance.GameSettings.ScorePerLine;
+            levelManager.OnScored?.Invoke(score);
+            Debug.Log($"[Codex] Score added {score}");
+        }
+
+        private RectTransform CreateDefaultRowVisual()
+        {
+            var go = new GameObject("RowVisual", typeof(RectTransform));
+            var rt = go.GetComponent<RectTransform>();
+            rt.SetParent(fieldManager.field, false);
+            var image = go.AddComponent<UnityEngine.UI.Image>();
+            image.color = new Color(1f, 0f, 0f, 0.3f);
+            rt.anchorMin = new Vector2(0, 0);
+            rt.anchorMax = new Vector2(0, 0);
+            rt.pivot = new Vector2(0, 0);
+            return rt;
+        }
+    }
+}

--- a/Scripts/BrickBlast/Gameplay/Boosters.cs.meta
+++ b/Scripts/BrickBlast/Gameplay/Boosters.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e591838abae40bfbdf5915ab2686356
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -551,8 +551,9 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             }
         }
 
-        private IEnumerator DestroyLines(List<List<Cell>> lines, Shape shape)
+        public IEnumerator DestroyLines(List<List<Cell>> lines, Shape shape)
         {
+            Debug.Log($"[Codex] DestroyLines called with {lines?.Count ?? 0} lines");
             SoundBase.instance.PlayLimitSound(SoundBase.instance.combo[Mathf.Min(comboCounter, SoundBase.instance.combo.Length - 1)]);
             EventManager.GetEvent<Shape>(EGameEvent.LineDestroyed).Invoke(shape);
 
@@ -562,12 +563,15 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                 foreach (var cell in line)
                 {
                     cell.SetDestroying(true);
+                    Debug.Log($"[Codex] Mark cell {cell.name} for destruction");
                 }
             }
-            
+
             foreach (var line in lines)
             {
                 if (line.Count == 0) continue;
+
+                Debug.Log("[Codex] Playing line explosion");
                 
                 var lineExplosion = lineExplosionPool.Get();
                 lineExplosion.Play(line, shape, RectTransformUtils.GetMinMaxAndSizeForCanvas(line, gameCanvas.GetComponent<Canvas>()), GetExplosionColor(shape));
@@ -577,13 +581,25 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                     cell.DestroyCell();
                 }
             }
-            
+
+            Debug.Log("[Codex] DestroyLines completed");
             yield return null;
         }
 
         private Color GetExplosionColor(Shape shape)
         {
-            var itemTemplateTopColor = shape.GetActiveItems()[0].itemTemplate.overlayColor;
+            if (shape == null)
+            {
+                return Color.white;
+            }
+
+            var items = shape.GetActiveItems();
+            if (items == null || items.Count == 0)
+            {
+                return Color.white;
+            }
+
+            var itemTemplateTopColor = items[0].itemTemplate.overlayColor;
             if (_levelData.levelType.singleColorMode)
             {
                 itemTemplateTopColor = itemFactory.GetOneColor().overlayColor;


### PR DESCRIPTION
## Summary
- add verbose [Codex] debug logging and fallback row overlay for delete-row booster
- instrument line destruction with [Codex] diagnostics

## Testing
- `dotnet test` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68988efa5b44832d82acccd39a480a85