### PR TITLE
Avoid NRE when no mismatch listeners

### DIFF
--- a/Scripts/MyCode/Database/Database.cs
+++ b/Scripts/MyCode/Database/Database.cs
@@ -309,7 +309,8 @@ namespace Ray.Services
                 {
                     _rayDebug.LogWarning($"{field.Key} - Server: {field.Value.oldValue}, Client: {field.Value.newValue}", this);
 
-                    EventService.Database.OnMismatchDetected.Invoke(this);
+                    // Ensure there is a listener before invoking to avoid null reference exceptions
+                    EventService.Database.OnMismatchDetected?.Invoke(this);
                     TenjinService.Instance.SendCheatEvent(field.Key, field.Value.oldValue.ToString(), field.Value.newValue.ToString());
                 }
 


### PR DESCRIPTION
## Summary
- Avoid null reference when reporting stat mismatches by using a null-conditional invocation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6899ab0e7364832dad4047925de88a72