### PR TITLE
Prevent destroyed SoundController being invoked

### DIFF
--- a/Scripts/MyCode/Controllers/SoundController.cs
+++ b/Scripts/MyCode/Controllers/SoundController.cs
@@ -68,6 +68,45 @@ namespace Ray.Controllers
             EventService.Item.OnObstacleCollected += PlayerHit;
         }
 
+        private void OnDisable()
+        {
+            EventService.UI.OnToggleSound -= ToggleSounds;
+
+            EventService.UI.OnStartBtn -= Click;
+            EventService.UI.OnSpaceUpgradeBtn -= Click;
+            EventService.UI.OnReachUpgradeBtn -= Click;
+            EventService.UI.OnToggleSound -= Click;
+
+            EventService.UI.OnToggleInsufficient -= Error;
+            EventService.UI.OnToggleDataMismatch -= Error;
+            EventService.UI.OnToggleTutorial -= OpenPopup;
+
+            EventService.UI.OnMeterStart -= RushMeter;
+
+            EventService.Resource.OnMenuResourceChanged -= Purchase;
+            EventService.IAP.OnPurchasedConsumable -= Purchase;
+            EventService.IAP.OnPurchasedSubscriptionNoAds -= Purchase;
+
+            EventService.Level.OnStart -= StartLevel;
+
+            EventService.Ad.OnReviveWatched -= AdReward;
+            EventService.Ad.OnTripleWatched -= AdReward;
+            EventService.Ad.OnNoEnemiesWatched -= AdReward;
+            EventService.Ad.OnFreeGiftWatched -= AdReward;
+            EventService.Ad.OnExtraSpaceWatched -= AdReward;
+
+            EventService.Item.OnItemCollected -= PlayItemCollection;
+            EventService.Item.OnObstacleCollected -= PlayerHit;
+        }
+
+        private void OnDestroy()
+        {
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+        }
+
         // Play Methods
         private void AdReward(Component c) => Play(SoundType.AdReward);
         private void Click(Component c) => Play(SoundType.Click);


### PR DESCRIPTION
## Summary
- Unsubscribe SoundController from events on disable
- Clear static SoundController instance when object is destroyed

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6899aefed324832d95517c435fb3916f