### PR TITLE
Use TotalCurrency for currency tracking

### DIFF
--- a/Scripts/BrickBlast/Data/ResourceObject.cs
+++ b/Scripts/BrickBlast/Data/ResourceObject.cs
@@ -59,7 +59,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Data
         {
             if (IsCoins)
             {
-                return Database.UserData?.Coins ?? DefaultValue;
+                return Database.UserData?.TotalCurrency ?? DefaultValue;
             }
 
             return PlayerPrefs.GetInt(ResourceName, DefaultValue);
@@ -73,7 +73,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Data
             {
                 if (Database.UserData != null)
                 {
-                    Database.UserData.Coins = Resource;
+                    Database.UserData.TotalCurrency = Resource;
                     Database.Instance?.Save(Database.UserData);
                 }
             }
@@ -92,7 +92,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Data
             {
                 if (Database.UserData != null)
                 {
-                    Database.UserData.Coins = Resource;
+                    Database.UserData.TotalCurrency = Resource;
                     Database.Instance?.Save(Database.UserData);
                 }
             }
@@ -112,11 +112,11 @@ namespace BlockPuzzleGameToolkit.Scripts.Data
                 Resource -= amount;
                 if (IsCoins)
                 {
-                    if (Database.UserData != null)
-                    {
-                        Database.UserData.Coins = Resource;
-                        Database.Instance?.Save(Database.UserData);
-                    }
+                if (Database.UserData != null)
+                {
+                    Database.UserData.TotalCurrency = Resource;
+                    Database.Instance?.Save(Database.UserData);
+                }
                 }
                 else
                 {

--- a/Scripts/BrickBlast/GUI/Labels/ResourceLabel.cs
+++ b/Scripts/BrickBlast/GUI/Labels/ResourceLabel.cs
@@ -27,8 +27,8 @@ namespace BlockPuzzleGameToolkit.Scripts.GUI.Labels
         {
             if (resourceObject != null && resourceObject.name == "Coins")
             {
-                Ray.Services.Database.UserData.CoinsChanged += UpdateValue;
-                UpdateValue(Ray.Services.Database.UserData.Coins);
+                Ray.Services.Database.UserData.TotalCurrencyChanged += UpdateValue;
+                UpdateValue(Ray.Services.Database.UserData.TotalCurrency);
             }
             else
             {
@@ -41,7 +41,7 @@ namespace BlockPuzzleGameToolkit.Scripts.GUI.Labels
         {
             if (resourceObject != null && resourceObject.name == "Coins")
             {
-                Ray.Services.Database.UserData.CoinsChanged -= UpdateValue;
+                Ray.Services.Database.UserData.TotalCurrencyChanged -= UpdateValue;
             }
             else
             {

--- a/Scripts/BrickBlast/Popups/CoinsShop.cs
+++ b/Scripts/BrickBlast/Popups/CoinsShop.cs
@@ -69,7 +69,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
             var count = shopItem.settingsShopItem.Value;
             LabelAnim.AnimateForResource(shopItem.resource, shopItem.BuyItemButton.transform.position, "+" + count, SoundBase.instance.coins, () =>
             {
-                Ray.Services.Database.UserData.AddCoins(count);
+                Ray.Services.Database.UserData.AddCurrency(count);
                 GetComponentInParent<Popup>().CloseDelay();
             });
 
@@ -103,7 +103,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
             var coins = GameManager.instance.GameSettings.coinsForAd;
             LabelAnim.AnimateForResource(watchAd.resource, watchAd.BuyItemButton.transform.position, "+" + coins, SoundBase.instance.coins, () =>
             {
-                Ray.Services.Database.UserData.AddCoins(coins);
+                Ray.Services.Database.UserData.AddCurrency(coins);
                 GetComponentInParent<Popup>().Close();
             });
         }

--- a/Scripts/BrickBlast/Popups/LuckySpin.cs
+++ b/Scripts/BrickBlast/Popups/LuckySpin.cs
@@ -138,7 +138,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
         private void BuySpin()
         {
             var data = Ray.Services.Database.UserData;
-            if (data.SpendCoins(spinSettings.costToSpin))
+            if (data.SpendCurrency(spinSettings.costToSpin))
             {
                 ShowCoinsSpendFX(buySpinButton.transform.position);
                 Spin();

--- a/Scripts/BrickBlast/Popups/PreFailed.cs
+++ b/Scripts/BrickBlast/Popups/PreFailed.cs
@@ -93,7 +93,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
             }
 
             var data = Ray.Services.Database.UserData;
-            if (data.SpendCoins(price))
+            if (data.SpendCurrency(price))
             {
                 hasContinued = true;
                 continueButton.interactable = false;

--- a/Scripts/MyCode/Database/Database.cs
+++ b/Scripts/MyCode/Database/Database.cs
@@ -177,7 +177,7 @@ namespace Ray.Services
 
             if (PlayerPrefs.HasKey("Coins"))
             {
-                UserData.Coins = PlayerPrefs.GetInt("Coins");
+                UserData.TotalCurrency = PlayerPrefs.GetInt("Coins");
                 changed = true;
             }
 

--- a/Scripts/MyCode/Database/UserData.cs
+++ b/Scripts/MyCode/Database/UserData.cs
@@ -13,23 +13,19 @@ public class UserData
     [FirestoreProperty] public FeaturesData Features { get; set; } = new FeaturesData();
     [FirestoreProperty] public brdData bightdData { get; set; } = new brdData();
 
-    public event Action<int> CoinsChanged;
+    public event Action<int> TotalCurrencyChanged;
     public event Action<int> LevelChanged;
-
-    private int coins;
     private int level = 1;
 
-    [FirestoreProperty]
-    public int Coins
+    public int TotalCurrency
     {
-        get => coins;
+        get => Stats.TotalCurrency;
         set
         {
-            if (coins != value)
+            if (Stats.TotalCurrency != value)
             {
-                coins = value;
                 Stats.TotalCurrency = value;
-                CoinsChanged?.Invoke(value);
+                TotalCurrencyChanged?.Invoke(value);
             }
         }
     }
@@ -112,18 +108,20 @@ public class UserData
         return JsonConvert.DeserializeObject<UserData>(json);
     }
 
-    public void AddCoins(int amount)
+    public void AddCurrency(int amount)
     {
-        Coins += amount;
-        Database.Instance?.Save(this);
+        var saveData = Database.UserData.Copy();
+        saveData.TotalCurrency += amount;
+        Database.Instance?.Save(saveData);
     }
 
-    public bool SpendCoins(int amount)
+    public bool SpendCurrency(int amount)
     {
-        if (Coins >= amount)
+        if (TotalCurrency >= amount)
         {
-            Coins -= amount;
-            Database.Instance?.Save(this);
+            var saveData = Database.UserData.Copy();
+            saveData.TotalCurrency -= amount;
+            Database.Instance?.Save(saveData);
             return true;
         }
         return false;
@@ -131,7 +129,8 @@ public class UserData
 
     public void SetLevel(int value)
     {
-        Level = value;
-        Database.Instance?.Save(this);
+        var saveData = Database.UserData.Copy();
+        saveData.Level = value;
+        Database.Instance?.Save(saveData);
     }
 }


### PR DESCRIPTION
## Summary
- replace coins property with TotalCurrency and expose AddCurrency/SpendCurrency helpers
- update database migration, resource, and UI code to rely on TotalCurrency instead of Coins

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6899ce1b027c832d809e6fac0ec1868e