### PR TITLE
Handle sub-level progression after win

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -512,7 +512,18 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
         private void SetWin()
         {
             GameDataManager.UnlockLevel(currentLevel + 1);
-            EventManager.GameStatus = EGameState.PreWin;
+            int subLevel = GameDataManager.GetSubLevelIndex();
+            if (subLevel < 3)
+            {
+                GameDataManager.SetSubLevelIndex(subLevel + 1);
+                GameManager.instance.OpenGame();
+                GameManager.instance.RestartLevel();
+            }
+            else
+            {
+                GameDataManager.ResetSubLevelIndex();
+                GameManager.instance.OpenMap();
+            }
         }
 
         private void SetLose()

--- a/Scripts/BrickBlast/System/GameDataManager.cs
+++ b/Scripts/BrickBlast/System/GameDataManager.cs
@@ -28,6 +28,24 @@ namespace BlockPuzzleGameToolkit.Scripts.System
 
         public static bool isTestPlay = false;
 
+        private const string SubLevelKey = "SubLevelIndex";
+
+        public static int GetSubLevelIndex()
+        {
+            return PlayerPrefs.GetInt(SubLevelKey, 1);
+        }
+
+        public static void SetSubLevelIndex(int index)
+        {
+            PlayerPrefs.SetInt(SubLevelKey, index);
+            PlayerPrefs.Save();
+        }
+
+        public static void ResetSubLevelIndex()
+        {
+            SetSubLevelIndex(1);
+        }
+
         public static void ClearPlayerProgress()
         {
             Database.UserData.SetLevel(1);

--- a/Scripts/BrickBlast/System/GameManager.cs
+++ b/Scripts/BrickBlast/System/GameManager.cs
@@ -214,6 +214,7 @@ namespace BlockPuzzleGameToolkit.Scripts.System
             }
             else
             {
+                GameDataManager.ResetSubLevelIndex();
                 SceneLoader.instance.StartMapScene();
             }
         }


### PR DESCRIPTION
## Summary
- Persist sub-level index across sessions
- Auto-advance or return to map after winning a level
- Reset sub-level progress when returning to map

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689aff3716ec832da8c9b7f202c8a6e0