### PR TITLE
Track unlocked level groups and adjust map logic

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -521,6 +521,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             }
             else
             {
+                int currentGroup = Mathf.CeilToInt(currentLevel / 3f);
+                GameDataManager.UnlockGroup(currentGroup + 1);
                 GameDataManager.ResetSubLevelIndex();
                 GameManager.instance.OpenMap();
             }

--- a/Scripts/BrickBlast/Map/ScrollableMap/LevelPin.cs
+++ b/Scripts/BrickBlast/Map/ScrollableMap/LevelPin.cs
@@ -20,7 +20,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Map.ScrollableMap
     public class LevelPin : MonoBehaviour
     {
         [SerializeField]
-        public int number = 1;
+        public int groupIndex = 1;
         [SerializeField]
         private GameObject lockObj;
         [SerializeField]
@@ -38,17 +38,17 @@ namespace BlockPuzzleGameToolkit.Scripts.Map.ScrollableMap
 
         private void OnValidate()
         {
-            number = transform.GetSiblingIndex() + 1;
-            name = "LevelGroup_" + number;
-            var start = (number - 1) * 3 + 1;
+            groupIndex = transform.GetSiblingIndex() + 1;
+            name = "LevelGroup_" + groupIndex;
+            var start = (groupIndex - 1) * 3 + 1;
             var end = start + 2;
             numberLabel.text = start + "-" + end;
         }
 
-        public void SetNumber(int number)
+        public void SetNumber(int groupIndex)
         {
-            this.number = number;
-            var start = (number - 1) * 3 + 1;
+            this.groupIndex = groupIndex;
+            var start = (groupIndex - 1) * 3 + 1;
             var end = start + 2;
             numberLabel.text = start + "-" + end;
         }
@@ -85,7 +85,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Map.ScrollableMap
         {
             if (isLocked)
                 return;
-            var startLevel = (number - 1) * 3 + 1;
+            var startLevel = (groupIndex - 1) * 3 + 1;
             ScrollableMapManager.instance.OpenLevel(startLevel);
         }
     }

--- a/Scripts/BrickBlast/Map/ScrollableMap/ScrollableMapManager.cs
+++ b/Scripts/BrickBlast/Map/ScrollableMap/ScrollableMapManager.cs
@@ -49,8 +49,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Map.ScrollableMap
         private void Start()
         {
             backButton.onClick.AddListener(SceneLoader.instance.GoMain);
-            var lvls = FindObjectsOfType<LevelPin>().OrderBy(x => x.number).ToArray();
-            var lastLevel = Mathf.CeilToInt(GameDataManager.GetLevelNum() / 3f);
+            var lvls = FindObjectsOfType<LevelPin>().OrderBy(x => x.groupIndex).ToArray();
+            var lastGroup = GameDataManager.GetGroupIndex();
 
             List<Vector3> fullPathPoints = new List<Vector3>();
             openedLevels.Clear();
@@ -59,14 +59,14 @@ namespace BlockPuzzleGameToolkit.Scripts.Map.ScrollableMap
             
             foreach (var levelPin in lvls)
             {
-                var start = (levelPin.number - 1) * 3 + 1;
+                var start = (levelPin.groupIndex - 1) * 3 + 1;
                 var end = start + 2;
                 levelPin.name = $"Level_{start}_{end}";
-                levelPin.SetNumber(levelPin.number);
+                levelPin.SetNumber(levelPin.groupIndex);
                 fullPathPoints.Add(levelPin.transform.position);
-                existingLevelNumbers.Add(levelPin.number);
+                existingLevelNumbers.Add(levelPin.groupIndex);
 
-                if (levelPin.number > lastLevel)
+                if (levelPin.groupIndex > lastGroup)
                 {
                     levelPin.Lock();
                 }
@@ -74,7 +74,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Map.ScrollableMap
                 {
                     levelPin.UnLock();
                     openedLevels.Add(levelPin);
-                    levelPin.SetCurrent(levelPin.number == lastLevel);
+                    levelPin.SetCurrent(levelPin.groupIndex == lastGroup);
                 }
             }
 
@@ -150,7 +150,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Map.ScrollableMap
             // Get total level groups from Resources for level number validation
             int totalLevelsInResources = Mathf.CeilToInt(Resources.LoadAll<LevelsData.Level>("Levels").Length / 3f);
             int baseLevelCount = originalLevels.Length;
-            var lastLevel = Mathf.CeilToInt(GameDataManager.GetLevelNum() / 3f);
+            var lastGroup = GameDataManager.GetGroupIndex();
             
             for (int repetition = 0; repetition < repetitions; repetition++)
             {
@@ -160,7 +160,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Map.ScrollableMap
                 foreach (var originalPin in originalLevels)
                 {
                     // Calculate the new level group number
-                    int newLevelNumber = baseLevelCount * (repetition + 1) + originalPin.number;
+                    int newLevelNumber = baseLevelCount * (repetition + 1) + originalPin.groupIndex;
 
                     // Skip if the level group number exceeds total available groups
                     if (newLevelNumber > totalLevelsInResources)
@@ -176,7 +176,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Map.ScrollableMap
                     newPin.SetNumber(newLevelNumber);
 
                     // Set lock state based on current progress
-                    if (newLevelNumber > lastLevel)
+                    if (newLevelNumber > lastGroup)
                     {
                         newPin.Lock();
                     }
@@ -187,7 +187,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Map.ScrollableMap
                         {
                             openedLevels.Add(newPin);
                         }
-                        newPin.SetCurrent(newLevelNumber == lastLevel);
+                        newPin.SetCurrent(newLevelNumber == lastGroup);
                     }
                 }
                 
@@ -282,8 +282,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Map.ScrollableMap
 
         private Vector3 GetPositionOpenedLevel()
         {
-            var currentLevel = Mathf.CeilToInt(GameDataManager.GetLevelNum() / 3f);
-            var currentLevelPin = openedLevels.FirstOrDefault(pin => pin.number == currentLevel);
+            var currentGroup = GameDataManager.GetGroupIndex();
+            var currentLevelPin = openedLevels.FirstOrDefault(pin => pin.groupIndex == currentGroup);
             return currentLevelPin != null ? currentLevelPin.transform.position : openedLevels[^1].transform.position;
         }
 
@@ -294,12 +294,12 @@ namespace BlockPuzzleGameToolkit.Scripts.Map.ScrollableMap
         
         public void UpdateLevelPinsAfterWin()
         {
-            var lastLevel = Mathf.CeilToInt(GameDataManager.GetLevelNum() / 3f);
-            var allLevelPins = levelsGrid.GetComponentsInChildren<LevelPin>().OrderBy(x => x.number).ToArray();
+            var lastGroup = GameDataManager.GetGroupIndex();
+            var allLevelPins = levelsGrid.GetComponentsInChildren<LevelPin>().OrderBy(x => x.groupIndex).ToArray();
             
             foreach (var levelPin in allLevelPins)
             {
-                if (levelPin.number > lastLevel)
+                if (levelPin.groupIndex > lastGroup)
                 {
                     levelPin.Lock();
                 }
@@ -310,7 +310,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Map.ScrollableMap
                     {
                         openedLevels.Add(levelPin);
                     }
-                    levelPin.SetCurrent(levelPin.number == lastLevel);
+                    levelPin.SetCurrent(levelPin.groupIndex == lastGroup);
                 }
             }
             

--- a/Scripts/BrickBlast/System/GameDataManager.cs
+++ b/Scripts/BrickBlast/System/GameDataManager.cs
@@ -49,6 +49,7 @@ namespace BlockPuzzleGameToolkit.Scripts.System
         public static void ClearPlayerProgress()
         {
             Database.UserData.SetLevel(1);
+            Database.UserData.SetGroupIndex(1);
         }
 
         public static void ClearALlData()
@@ -66,6 +67,7 @@ namespace BlockPuzzleGameToolkit.Scripts.System
             PlayerPrefs.DeleteAll();
             PlayerPrefs.Save();
             Database.UserData.SetLevel(1);
+            Database.UserData.SetGroupIndex(1);
             #endif
         }
 
@@ -79,9 +81,23 @@ namespace BlockPuzzleGameToolkit.Scripts.System
             }
         }
 
+        public static void UnlockGroup(int groupIndex)
+        {
+            int savedGroup = Database.UserData.GroupIndex;
+            if (savedGroup < groupIndex)
+            {
+                Database.UserData.SetGroupIndex(groupIndex);
+            }
+        }
+
         public static int GetLevelNum()
         {
             return Database.UserData.Level;
+        }
+
+        public static int GetGroupIndex()
+        {
+            return Database.UserData.GroupIndex;
         }
 
         public static Level GetLevel()
@@ -120,6 +136,7 @@ namespace BlockPuzzleGameToolkit.Scripts.System
         {
             var levels = Resources.LoadAll<Level>("Levels").Length;
             Database.UserData.SetLevel(levels);
+            Database.UserData.SetGroupIndex(Mathf.CeilToInt(levels / 3f));
         }
 
         internal static bool HasMoreLevels()

--- a/Scripts/MyCode/Database/UserData.cs
+++ b/Scripts/MyCode/Database/UserData.cs
@@ -16,7 +16,9 @@ public class UserData
 
     public event Action<int> TotalCurrencyChanged;
     public event Action<int> LevelChanged;
+    public event Action<int> GroupIndexChanged;
     private int level = 1;
+    private int groupIndex = 1;
 
     public int TotalCurrency
     {
@@ -42,6 +44,20 @@ public class UserData
                 level = value;
                 Stats.ReachLevel = value;
                 LevelChanged?.Invoke(value);
+            }
+        }
+    }
+
+    [FirestoreProperty]
+    public int GroupIndex
+    {
+        get => groupIndex;
+        set
+        {
+            if (groupIndex != value)
+            {
+                groupIndex = value;
+                GroupIndexChanged?.Invoke(value);
             }
         }
     }
@@ -132,6 +148,13 @@ public class UserData
     {
         var saveData = Database.UserData.Copy();
         saveData.Level = value;
+        Database.Instance?.Save(saveData);
+    }
+
+    public void SetGroupIndex(int value)
+    {
+        var saveData = Database.UserData.Copy();
+        saveData.GroupIndex = value;
         Database.Instance?.Save(saveData);
     }
 }


### PR DESCRIPTION
## Summary
- record highest unlocked level group in user data
- unlock next group only when sub-level 3 is cleared
- drive map pins by group index for locking and navigation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689b111797ac832da6f0bb23af92f31e