### PR TITLE
Add change shape booster

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/BoosterManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/BoosterManager.cs
@@ -15,6 +15,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
         [SerializeField] private Button rowButton;
         [SerializeField] private Button columnButton;
         [SerializeField] private Button squareButton;
+        [SerializeField] private Button changeShapeButton;
 
         private Cell lastHighlightedCell;
         private Camera mainCamera;
@@ -42,6 +43,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                 columnButton.onClick.AddListener(() => SelectBooster(BoosterType.ClearColumn));
             if (squareButton != null)
                 squareButton.onClick.AddListener(() => SelectBooster(BoosterType.ClearSquare));
+            if (changeShapeButton != null)
+                changeShapeButton.onClick.AddListener(() => SelectBooster(BoosterType.ChangeShape));
         }
 
         private void OnDestroy()
@@ -51,7 +54,23 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 
         public void SelectBooster(BoosterType booster)
         {
+            if (booster == BoosterType.ChangeShape)
+            {
+                ChangeShapes();
+                return;
+            }
+
             activeBooster = booster;
+        }
+
+        private void ChangeShapes()
+        {
+            var deckManager = FindObjectOfType<CellDeckManager>();
+            if (deckManager != null)
+            {
+                deckManager.UpdateCellDeckAfterFail();
+            }
+            activeBooster = null;
         }
 
         private void Update()
@@ -165,6 +184,9 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                                     break;
                                 case BoosterType.ClearSquare:
                                     FillSquare(row, col);
+                                    break;
+                                case BoosterType.ChangeShape:
+                                    ChangeShapes();
                                     break;
                             }
                             activeBooster = null;

--- a/Scripts/BrickBlast/RayBrickMediator.cs
+++ b/Scripts/BrickBlast/RayBrickMediator.cs
@@ -32,10 +32,12 @@ public class RayBrickMediator : MonoBehaviour
             SetupBoosterButton(Shop.ClearRow, BoosterType.ClearRow);
             SetupBoosterButton(Shop.ClearColumn, BoosterType.ClearColumn);
             SetupBoosterButton(Shop.ClearSquare, BoosterType.ClearSquare);
+            SetupBoosterButton(Shop.ChangeShape, BoosterType.ChangeShape);
 
             SetupUseBoosterButton(Level.ClearRow, BoosterType.ClearRow);
             SetupUseBoosterButton(Level.ClearColumn, BoosterType.ClearColumn);
             SetupUseBoosterButton(Level.ClearSquare, BoosterType.ClearSquare);
+            SetupUseBoosterButton(Level.ChangeShape, BoosterType.ChangeShape);
 
             EventService.Resource.OnMenuResourceChanged += RefreshShop;
             RefreshShop(this);
@@ -66,6 +68,7 @@ public class RayBrickMediator : MonoBehaviour
             public BoosterItem ClearRow;
             public BoosterItem ClearColumn;
             public BoosterItem ClearSquare;
+            public BoosterItem ChangeShape;
         }
 
         [Header("Booster Shop")] public BoosterShopElements Shop = new BoosterShopElements();
@@ -76,6 +79,7 @@ public class RayBrickMediator : MonoBehaviour
             public GameObject ClearRow;
             public GameObject ClearColumn;
             public GameObject ClearSquare;
+            public GameObject ChangeShape;
         }
 
         [Header("Level Boosters")] public BoosterLevelElements Level = new BoosterLevelElements();
@@ -131,6 +135,7 @@ public class RayBrickMediator : MonoBehaviour
             RefreshBoosterItem(Shop.ClearRow, Database.UserData.Stats.Power_1);
             RefreshBoosterItem(Shop.ClearColumn, Database.UserData.Stats.Power_2);
             RefreshBoosterItem(Shop.ClearSquare, Database.UserData.Stats.Power_3);
+            RefreshBoosterItem(Shop.ChangeShape, Database.UserData.Stats.Power_4);
             Shop.Currency.text = Database.UserData.Stats.TotalCurrency.ToString();
         }
 
@@ -155,6 +160,7 @@ public class RayBrickMediator : MonoBehaviour
             Shop.ClearRow.Price = CalculateBoosterPrice(Database.UserData.Stats.Power_1);
             Shop.ClearColumn.Price = CalculateBoosterPrice(Database.UserData.Stats.Power_2);
             Shop.ClearSquare.Price = CalculateBoosterPrice(Database.UserData.Stats.Power_3);
+            Shop.ChangeShape.Price = CalculateBoosterPrice(Database.UserData.Stats.Power_4);
         }
 
         private int CalculateBoosterPrice(int amount)

--- a/Scripts/MyCode/Database/Database.cs
+++ b/Scripts/MyCode/Database/Database.cs
@@ -234,6 +234,7 @@ namespace Ray.Services
                     int defaultPower1 = defaultData.ContainsKey("Power_1") ? Convert.ToInt32(defaultData["Power_1"]) : 0;
                     int defaultPower2 = defaultData.ContainsKey("Power_2") ? Convert.ToInt32(defaultData["Power_2"]) : 0;
                     int defaultPower3 = defaultData.ContainsKey("Power_3") ? Convert.ToInt32(defaultData["Power_3"]) : 0;
+                    int defaultPower4 = defaultData.ContainsKey("Power_4") ? Convert.ToInt32(defaultData["Power_4"]) : 0;
 
                     Timestamp currentTime = await TimeApiService.Instance.GetCurrentTime();
 
@@ -252,7 +253,8 @@ namespace Ray.Services
                             SpaceLevel = defaultSpaceLevel,
                             Power_1 = defaultPower1,
                             Power_2 = defaultPower2,
-                            Power_3 = defaultPower3
+                            Power_3 = defaultPower3,
+                            Power_4 = defaultPower4
                         },
 
                         Level = defaultLevel

--- a/Scripts/MyCode/Database/UserData.cs
+++ b/Scripts/MyCode/Database/UserData.cs
@@ -90,6 +90,7 @@ public class UserData
         [FirestoreProperty] public int Power_1 { get; set; } = 0;
         [FirestoreProperty] public int Power_2 { get; set; } = 0;
         [FirestoreProperty] public int Power_3 { get; set; } = 0;
+        [FirestoreProperty] public int Power_4 { get; set; } = 0;
     }
 
     [FirestoreData]

--- a/Scripts/MyCode/Mediators/UIEventMediator.cs
+++ b/Scripts/MyCode/Mediators/UIEventMediator.cs
@@ -25,6 +25,7 @@ public class UIEventMediator : MonoBehaviour
     public void _OnBuyClearRow(int cost) => EventService.UI.OnBoosterPurchaseBtn.Invoke(this, BoosterType.ClearRow, cost);
     public void _OnBuyClearColumn(int cost) => EventService.UI.OnBoosterPurchaseBtn.Invoke(this, BoosterType.ClearColumn, cost);
     public void _OnBuyClearSquare(int cost) => EventService.UI.OnBoosterPurchaseBtn.Invoke(this, BoosterType.ClearSquare, cost);
+    public void _OnBuyChangeShape(int cost) => EventService.UI.OnBoosterPurchaseBtn.Invoke(this, BoosterType.ChangeShape, cost);
 
     // Rewarded
     public void _OnPenaltyBtn() => EventService.UI.OnRewardedBtn.Invoke(this, RewardedType.Penalty);

--- a/Scripts/MyCode/Services/BoosterType.cs
+++ b/Scripts/MyCode/Services/BoosterType.cs
@@ -6,6 +6,7 @@ namespace Ray.Services
     {
         ClearRow,
         ClearColumn,
-        ClearSquare
+        ClearSquare,
+        ChangeShape
     }
 }

--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -145,6 +145,10 @@ namespace Ray.Services
                     if (saveData.Stats.Power_3 >= 99) return;
                     saveData.Stats.Power_3 = Mathf.Clamp(saveData.Stats.Power_3 + 1, 0, 99);
                     break;
+                case BoosterType.ChangeShape:
+                    if (saveData.Stats.Power_4 >= 99) return;
+                    saveData.Stats.Power_4 = Mathf.Clamp(saveData.Stats.Power_4 + 1, 0, 99);
+                    break;
             }
 
             saveData.Stats.TotalCurrency -= cost;


### PR DESCRIPTION
## Summary
- add `ChangeShape` booster type
- support replacing current deck shapes via BoosterManager
- wire change-shape booster through UI, resources, and user data

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b15bd4eb0832dadb42de59b65c750