### PR TITLE
Consume booster on use and refresh shop

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/BoosterManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/BoosterManager.cs
@@ -189,7 +189,11 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                                     ChangeShapes();
                                     break;
                             }
-                            activeBooster = null;
+                            if (activeBooster.HasValue)
+                            {
+                                ResourceService.Instance?.ConsumeBooster(activeBooster.Value);
+                                activeBooster = null;
+                            }
                             lastHighlightedCell = null;
                             return;
                         }

--- a/Scripts/BrickBlast/RayBrickMediator.cs
+++ b/Scripts/BrickBlast/RayBrickMediator.cs
@@ -129,9 +129,8 @@ public class RayBrickMediator : MonoBehaviour
             });
         }
 
-        private void RefreshShop(Component c)
+        public void RefreshShop(Component c)
         {
-
             RefreshBoosterItem(Shop.ClearRow, Database.UserData.Stats.Power_1);
             RefreshBoosterItem(Shop.ClearColumn, Database.UserData.Stats.Power_2);
             RefreshBoosterItem(Shop.ClearSquare, Database.UserData.Stats.Power_3);

--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -158,6 +158,32 @@ namespace Ray.Services
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
         }
 
+        public async void ConsumeBooster(BoosterType type)
+        {
+            var saveData = Database.UserData.Copy();
+
+            switch (type)
+            {
+                case BoosterType.ClearRow:
+                    saveData.Stats.Power_1 = Mathf.Clamp(saveData.Stats.Power_1 - 1, 0, 99);
+                    break;
+                case BoosterType.ClearColumn:
+                    saveData.Stats.Power_2 = Mathf.Clamp(saveData.Stats.Power_2 - 1, 0, 99);
+                    break;
+                case BoosterType.ClearSquare:
+                    saveData.Stats.Power_3 = Mathf.Clamp(saveData.Stats.Power_3 - 1, 0, 99);
+                    break;
+                case BoosterType.ChangeShape:
+                    saveData.Stats.Power_4 = Mathf.Clamp(saveData.Stats.Power_4 - 1, 0, 99);
+                    break;
+            }
+
+            await Database.Instance.Save(saveData);
+
+            EventService.Resource.OnMenuResourceChanged.Invoke(this);
+            RayBrickMediator.Instance?.RefreshShop(this);
+        }
+
         public async void RewardNoEnemies(Component c)
         {
             _rayDebug.Event("RewardNoEnemies", c, this);


### PR DESCRIPTION
## Summary
- Add `ConsumeBooster` in `ResourceService` to decrement booster counts, persist them, and refresh the shop UI.
- Invoke `ResourceService.ConsumeBooster` when a booster is used in `BoosterManager`.
- Expose `RayBrickMediator.RefreshShop` so it can be called after saving booster consumption.

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_689b20a0d438832d8a376316efb6cc92