### PR TITLE
Prevent using boosters when none available

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/BoosterManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/BoosterManager.cs
@@ -54,6 +54,13 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 
         public void SelectBooster(BoosterType booster)
         {
+            // Prevent using boosters when the player has none available
+            if (GetBoosterCount(booster) <= 0)
+            {
+                EventService.UI.OnToggleInsufficient?.Invoke(this);
+                return;
+            }
+
             if (booster == BoosterType.ChangeShape)
             {
                 ChangeShapes();
@@ -61,6 +68,23 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             }
 
             activeBooster = booster;
+        }
+
+        private int GetBoosterCount(BoosterType booster)
+        {
+            switch (booster)
+            {
+                case BoosterType.ClearRow:
+                    return Database.UserData.Stats.Power_1;
+                case BoosterType.ClearColumn:
+                    return Database.UserData.Stats.Power_2;
+                case BoosterType.ClearSquare:
+                    return Database.UserData.Stats.Power_3;
+                case BoosterType.ChangeShape:
+                    return Database.UserData.Stats.Power_4;
+                default:
+                    return 0;
+            }
         }
 
         private void ChangeShapes()


### PR DESCRIPTION
## Summary
- Guard booster activation if player has zero of that booster
- Add helper for fetching booster counts to reuse logic

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689b2736bfac832d807de9c01ff3f84e