### PR TITLE
Consume ChangeShape booster when used

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/BoosterManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/BoosterManager.cs
@@ -94,6 +94,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             {
                 deckManager.UpdateCellDeckAfterFail();
             }
+            ResourceService.Instance?.ConsumeBooster(BoosterType.ChangeShape);
             activeBooster = null;
         }
 


### PR DESCRIPTION
## Summary
- Consume ChangeShape booster immediately after updating the deck
- Keep active booster cleared since no cell interaction is needed

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_689b29108308832dbcf093ec29e78240