### PR TITLE
Add score-based currency helper

### DIFF
--- a/Scripts/MyCode/Database/UserData.cs
+++ b/Scripts/MyCode/Database/UserData.cs
@@ -133,6 +133,14 @@ public class UserData
         await Database.Instance?.Save(saveData);
     }
 
+    public async Task AddScoreAsCurrency(int score)
+    {
+        var saveData = Copy();
+        saveData.Stats.TotalCurrency += score;
+        saveData.Stats.TotalSessions++;
+        await Database.Instance.Save(saveData);
+    }
+
     public async Task<bool> SpendCurrency(int amount)
     {
         if (TotalCurrency >= amount)

--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -1,3 +1,4 @@
+using BlockPuzzleGameToolkit.Scripts.Gameplay;
 using Firebase.Firestore;
 using System;
 using System.Linq;
@@ -237,11 +238,11 @@ namespace Ray.Services
         {
             _rayDebug.Event("RewardEndCurrency", c, this);
 
-            var saveData = Database.UserData.Copy();
-            saveData.Stats.TotalCurrency += LevelCurrency.Value;
-            saveData.Stats.TotalSessions++;
+            var handler = FindObjectsOfType<BaseModeHandler>().FirstOrDefault(h => h.isActiveAndEnabled);
+            int total = LevelCurrency.Value + (handler?.score ?? 0);
 
-            await Database.Instance.Save(saveData);
+            await Database.UserData.AddScoreAsCurrency(total);
+            handler?.ResetScore();
 
             EventService.Resource.OnEndCurrencyChanged(this);
         }


### PR DESCRIPTION
## Summary
- add AddScoreAsCurrency helper to persist level score as currency and count sessions
- reward currency now includes score from active BaseModeHandler and resets it after saving

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403, unable to install dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_689b3d1f0b9c832db85498610c9b0a5c