### PR TITLE
Track level score via ResourceService

### DIFF
--- a/Scripts/BrickBlast/Gameplay/BaseModeHandler.cs
+++ b/Scripts/BrickBlast/Gameplay/BaseModeHandler.cs
@@ -4,6 +4,7 @@ using BlockPuzzleGameToolkit.Scripts.Enums;
 using TMPro;
 using UnityEngine;
 using System.Collections;
+using Ray.Services;
 
 namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 {
@@ -36,6 +37,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 
             _levelManager.OnLose += OnLose;
             _levelManager.OnScored += OnScored;
+            EventService.Resource.OnEndCurrencyChanged += HandleEndCurrencyChanged;
 
             // ResetScore();
             LoadScores();
@@ -48,6 +50,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                 _levelManager.OnLose -= OnLose;
                 _levelManager.OnScored -= OnScored;
             }
+            EventService.Resource.OnEndCurrencyChanged -= HandleEndCurrencyChanged;
         }
 
         protected virtual void OnApplicationPause(bool pauseStatus)
@@ -104,7 +107,13 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 
         public virtual void OnLose()
         {
+            ResourceService.Instance?.SubmitLevelScore(score);
             DeleteGameState();
+        }
+
+        private void HandleEndCurrencyChanged(Component c)
+        {
+            ResetScore();
         }
 
         public virtual void UpdateScore(int newScore)

--- a/Scripts/MyCode/Database/UserData.cs
+++ b/Scripts/MyCode/Database/UserData.cs
@@ -133,6 +133,14 @@ public class UserData
         await Database.Instance?.Save(saveData);
     }
 
+    public async Task AddScoreAsCurrency(int score)
+    {
+        var saveData = Database.UserData.Copy();
+        saveData.Stats.TotalCurrency += score;
+        saveData.Stats.TotalSessions++;
+        await Database.Instance?.Save(saveData);
+    }
+
     public async Task<bool> SpendCurrency(int amount)
     {
         if (TotalCurrency >= amount)

--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -13,6 +13,7 @@ namespace Ray.Services
         [SerializeField, RequireReference] private ResourceEvaluationConfig _resourceEvaluationConfig;
 
         [HideInInspector] public EncryptedField<int> LevelCurrency = new EncryptedField<int>(0);
+        [HideInInspector] public EncryptedField<int> LevelScore = new EncryptedField<int>(0);
         [HideInInspector] public EncryptedField<int> LevelSpace = new EncryptedField<int>(0);
         [HideInInspector] public EncryptedField<int> LevelsPlayed = new EncryptedField<int>(0);
         [HideInInspector] public EncryptedField<bool> NoEnemies = new EncryptedField<bool>(false);
@@ -52,6 +53,11 @@ namespace Ray.Services
         private void ProcessSpaceUpgrade(Component c) => ProcessUpgrade(c, UpgradeType.Space);
 
         private void ProcessReachUpgrade(Component c) => ProcessUpgrade(c, UpgradeType.Reach);
+
+        public void SubmitLevelScore(int score)
+        {
+            LevelScore.Value = score;
+        }
 
         private async void ProcessUpgrade(Component c, UpgradeType upgradeType)
         {
@@ -202,6 +208,7 @@ namespace Ray.Services
             _rayDebug.Event("ResetLevelResources", c, this);
 
             LevelCurrency.Value = 0;
+            LevelScore.Value = 0;
 
             LevelSpace.Value = Database.UserData.Stats.SpaceLevel;
 
@@ -237,11 +244,11 @@ namespace Ray.Services
         {
             _rayDebug.Event("RewardEndCurrency", c, this);
 
-            var saveData = Database.UserData.Copy();
-            saveData.Stats.TotalCurrency += LevelCurrency.Value;
-            saveData.Stats.TotalSessions++;
+            int total = LevelCurrency.Value + LevelScore.Value;
 
-            await Database.Instance.Save(saveData);
+            LevelCurrency.Value = total;
+            await Database.UserData.AddScoreAsCurrency(total);
+            LevelScore.Value = 0;
 
             EventService.Resource.OnEndCurrencyChanged(this);
         }


### PR DESCRIPTION
## Summary
- maintain a transient `LevelScore` in `ResourceService` and expose `SubmitLevelScore`
- reward end-of-level currency by merging the stored score, then clear it
- mode handler submits its score on loss and resets when currency is saved

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b3d1f0b9c832db85498610c9b0a5c