### PR TITLE
Collect mode score in reward

### DIFF
--- a/Scripts/BrickBlast/Gameplay/BaseModeHandler.cs
+++ b/Scripts/BrickBlast/Gameplay/BaseModeHandler.cs
@@ -4,6 +4,7 @@ using BlockPuzzleGameToolkit.Scripts.Enums;
 using TMPro;
 using UnityEngine;
 using System.Collections;
+using Ray.Services;
 
 namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 {
@@ -37,7 +38,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             _levelManager.OnLose += OnLose;
             _levelManager.OnScored += OnScored;
 
-            // ResetScore();
+            EventService.Resource.OnEndCurrencyChanged += HandleEndCurrencyChanged;
+
             LoadScores();
         }
 
@@ -48,6 +50,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                 _levelManager.OnLose -= OnLose;
                 _levelManager.OnScored -= OnScored;
             }
+
+            EventService.Resource.OnEndCurrencyChanged -= HandleEndCurrencyChanged;
         }
 
         protected virtual void OnApplicationPause(bool pauseStatus)
@@ -104,7 +108,13 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 
         public virtual void OnLose()
         {
+            ResourceService.Instance?.SubmitLevelScore(score);
             DeleteGameState();
+        }
+
+        private void HandleEndCurrencyChanged(Component c)
+        {
+            ResetScore();
         }
 
         public virtual void UpdateScore(int newScore)

--- a/Scripts/MyCode/Database/UserData.cs
+++ b/Scripts/MyCode/Database/UserData.cs
@@ -133,6 +133,14 @@ public class UserData
         await Database.Instance?.Save(saveData);
     }
 
+    public async Task AddScoreAsCurrency(int score)
+    {
+        var saveData = Database.UserData.Copy();
+        saveData.Stats.TotalCurrency += score;
+        saveData.Stats.TotalSessions++;
+        await Database.Instance?.Save(saveData);
+    }
+
     public async Task<bool> SpendCurrency(int amount)
     {
         if (TotalCurrency >= amount)


### PR DESCRIPTION
## Summary
- track per-level score in `ResourceService` and merge with collected currency without referencing gameplay handlers
- let mode handlers submit their score and reset when end-of-level currency is processed

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b3d1f0b9c832db85498610c9b0a5c