### PR TITLE
Collect mode score in reward

### DIFF
--- a/Scripts/BrickBlast/Gameplay/BaseModeHandler.cs
+++ b/Scripts/BrickBlast/Gameplay/BaseModeHandler.cs
@@ -4,6 +4,7 @@ using BlockPuzzleGameToolkit.Scripts.Enums;
 using TMPro;
 using UnityEngine;
 using System.Collections;
+using Ray.Services;
 
 namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 {
@@ -37,7 +38,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             _levelManager.OnLose += OnLose;
             _levelManager.OnScored += OnScored;
 
-            // ResetScore();
+            EventService.Resource.OnEndCurrencyChanged += HandleEndCurrencyChanged;
+
             LoadScores();
         }
 
@@ -48,6 +50,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                 _levelManager.OnLose -= OnLose;
                 _levelManager.OnScored -= OnScored;
             }
+
+            EventService.Resource.OnEndCurrencyChanged -= HandleEndCurrencyChanged;
         }
 
         protected virtual void OnApplicationPause(bool pauseStatus)
@@ -104,7 +108,13 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 
         public virtual void OnLose()
         {
+            ResourceService.Instance?.SubmitLevelScore(score);
             DeleteGameState();
+        }
+
+        private void HandleEndCurrencyChanged(Component c)
+        {
+            ResetScore();
         }
 
         public virtual void UpdateScore(int newScore)

--- a/Scripts/MyCode/Database/UserData.cs
+++ b/Scripts/MyCode/Database/UserData.cs
@@ -133,6 +133,14 @@ public class UserData
         await Database.Instance?.Save(saveData);
     }
 
+    public async Task AddScoreAsCurrency(int score)
+    {
+        var saveData = Database.UserData.Copy();
+        saveData.Stats.TotalCurrency += score;
+        saveData.Stats.TotalSessions++;
+        await Database.Instance?.Save(saveData);
+    }
+
     public async Task<bool> SpendCurrency(int amount)
     {
         if (TotalCurrency >= amount)

--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -13,6 +13,8 @@ namespace Ray.Services
         [SerializeField, RequireReference] private ResourceEvaluationConfig _resourceEvaluationConfig;
 
         [HideInInspector] public EncryptedField<int> LevelCurrency = new EncryptedField<int>(0);
+        // Transient score submitted by gameplay handlers, merged with currency at level end
+        [HideInInspector] public EncryptedField<int> LevelScore = new EncryptedField<int>(0);
         [HideInInspector] public EncryptedField<int> LevelSpace = new EncryptedField<int>(0);
         [HideInInspector] public EncryptedField<int> LevelsPlayed = new EncryptedField<int>(0);
         [HideInInspector] public EncryptedField<bool> NoEnemies = new EncryptedField<bool>(false);
@@ -197,12 +199,17 @@ namespace Ray.Services
             EventService.Resource.OnNoEnemiesReceived.Invoke(this);
         }
 
+        public void SubmitLevelScore(int score)
+        {
+            LevelScore.Value = score;
+        }
+
         private void ResetLevelResources(Component c)
         {
             _rayDebug.Event("ResetLevelResources", c, this);
 
             LevelCurrency.Value = 0;
-
+            LevelScore.Value = 0;
             LevelSpace.Value = Database.UserData.Stats.SpaceLevel;
 
             EventService.Resource.OnLevelResourceChanged.Invoke(this);
@@ -236,12 +243,11 @@ namespace Ray.Services
         private async void RewardEndCurrency(Component c)
         {
             _rayDebug.Event("RewardEndCurrency", c, this);
+            int total = LevelCurrency.Value + LevelScore.Value;
 
-            var saveData = Database.UserData.Copy();
-            saveData.Stats.TotalCurrency += LevelCurrency.Value;
-            saveData.Stats.TotalSessions++;
-
-            await Database.Instance.Save(saveData);
+            LevelCurrency.Value = total;
+            await Database.UserData.AddScoreAsCurrency(total);
+            LevelScore.Value = 0;
 
             EventService.Resource.OnEndCurrencyChanged(this);
         }


### PR DESCRIPTION
## Summary
- track per-level score in `ResourceService` and merge with collected currency without referencing gameplay handlers
- let mode handlers submit their score and reset when end-of-level currency is processed
- document that level score is a transient store for mode handlers

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b3d1f0b9c832db85498610c9b0a5c