### PR TITLE
Fix duplicate SubmitLevelScore method

### DIFF
--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -208,11 +208,6 @@ namespace Ray.Services
             EventService.Resource.OnNoEnemiesReceived.Invoke(this);
         }
 
-        public void SubmitLevelScore(int score)
-        {
-            LevelScore.Value = score;
-        }
-
         private void ResetLevelResources(Component c)
         {
             _rayDebug.Event("ResetLevelResources", c, this);


### PR DESCRIPTION
## Summary
- remove duplicate `SubmitLevelScore` definition to fix CS0111 compile error

## Testing
- `mcs Scripts/MyCode/Services/ResourceService.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c3dcabfa0832d8f330b3ca3a541db