### PR TITLE
Consolidate end-of-level currency handling

### DIFF
--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -248,35 +248,13 @@ namespace Ray.Services
         private async void RewardEndCurrency(Component c)
         {
             _rayDebug.Event("RewardEndCurrency", c, this);
-            int total = LevelCurrency.Value + LevelScore.Value;
 
-
-            LevelCurrency.Value = total;
-            await Database.UserData.AddScoreAsCurrency(total);
-            LevelScore.Value = 0;
-
-
-
-            LevelCurrency.Value = total;
-            await Database.UserData.AddScoreAsCurrency(total);
-            LevelScore.Value = 0;
-
-
+            // Combine any transient level earnings with collected currency
             int total = LevelCurrency.Value + LevelScore.Value;
 
             LevelCurrency.Value = total;
             await Database.UserData.AddScoreAsCurrency(total);
             LevelScore.Value = 0;
-
-            var handler = FindObjectsOfType<BaseModeHandler>().FirstOrDefault(h => h.isActiveAndEnabled);
-            int total = LevelCurrency.Value + (handler?.score ?? 0);
-
-            LevelCurrency.Value = total;
-            await Database.UserData.AddScoreAsCurrency(total);
-            handler?.ResetScore();
-
-
-
 
             EventService.Resource.OnEndCurrencyChanged(this);
         }


### PR DESCRIPTION
## Summary
- simplify RewardEndCurrency by merging level score with currency once
- remove BaseModeHandler dependency and reset logic to avoid missing type

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c3f60d49c832dae158ac3e6e2037f