### PR TITLE
Add revive feature with rewarded ad support

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.State.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.State.cs
@@ -29,6 +29,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 
             if (newState == EGameState.Failed)
             {
+                failedLevel = this.currentLevel;
+                failedSubLevelIndex = GameDataManager.GetSubLevelIndex();
                 HandleLevelFail();
             }
         }

--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -23,6 +23,7 @@ using BlockPuzzleGameToolkit.Scripts.Gameplay.Pool;
 using BlockPuzzleGameToolkit.Scripts.LevelsData;
 using BlockPuzzleGameToolkit.Scripts.System;
 using BlockPuzzleGameToolkit.Scripts.Utils;
+using BlockPuzzleGameToolkit.Scripts.Popups;
 using DG.Tweening;
 using TMPro;
 using UnityEngine;
@@ -84,9 +85,12 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
         private TimedModeHandler timedModeHandler;
         public TimerManager timerManager;
         private int timerDuration;
-        
+
         private Vector3 cachedFieldCenter;
         private bool isFieldCenterCached;
+
+        private int failedLevel;
+        private int failedSubLevelIndex;
 
         private void OnEnable()
         {
@@ -571,6 +575,19 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             {
                 cell.ClearCell();
             }
+        }
+
+        public void ReviveCurrentStage()
+        {
+            ClearEmptyCells();
+            cellDeck.UpdateCellDeckAfterFail();
+
+            currentLevel = failedLevel;
+            GameDataManager.SetLevelNum(failedLevel);
+            GameDataManager.SetSubLevelIndex(failedSubLevelIndex);
+
+            EventManager.GameStatus = EGameState.Playing;
+            MenuManager.instance.popupStack.OfType<PreFailed>().FirstOrDefault()?.Close();
         }
 
         public IEnumerator DestroyLines(List<List<Cell>> lines, Shape shape)

--- a/Scripts/BrickBlast/Popups/PreFailed.cs
+++ b/Scripts/BrickBlast/Popups/PreFailed.cs
@@ -16,6 +16,8 @@ using BlockPuzzleGameToolkit.Scripts.GUI;
 using BlockPuzzleGameToolkit.Scripts.System;
 using DG.Tweening;
 using TMPro;
+using BlockPuzzleGameToolkit.Scripts.Gameplay;
+using Ray.Services;
 
 namespace BlockPuzzleGameToolkit.Scripts.Popups
 {
@@ -25,16 +27,29 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
         public TextMeshProUGUI timerText;
         public CustomButton continueButton;
         public CustomButton rewardButton;
+        public CustomButton reviveButton;
         public TextMeshProUGUI timeLeftText;
         protected int timer;
         protected int price;
         protected bool hasContinued = false;
+
+        private LevelManager levelManager;
 
         protected virtual void OnEnable()
         {
             price = GameManager.instance.GameSettings.continuePrice;
             continuePrice.text = price.ToString();
             continueButton.onClick.AddListener(Continue);
+
+            levelManager = FindObjectOfType<LevelManager>();
+            if (reviveButton != null)
+            {
+                reviveButton.onClick.AddListener(() =>
+                {
+                    Close();
+                    RewardedService.Instance.ShowRewarded(RewardedType.Revive, levelManager.ReviveCurrentStage);
+                });
+            }
             
             InitializeTimer();
             


### PR DESCRIPTION
## Summary
- Expose `ReviveCurrentStage` to clean board, restore level progress, resume gameplay, and close fail popup
- Cache level and sub-level when entering failed state for reviving
- Wire revive button to rewarded ad that triggers revival after watching

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689d94b46a64832d98d5c75cf28cd099