### PR TITLE
Route revive button through mediator and reward service callback

### DIFF
--- a/Ads/RewardedService.cs
+++ b/Ads/RewardedService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using UnityEngine;
@@ -11,6 +12,7 @@ namespace Ray.Services
 
         private Dictionary<string, string> _adUnits;
         private RewardedType _currentRewarededType;
+        private Action _onRewarded;
 
         public static RewardedService Instance;
 
@@ -118,6 +120,12 @@ namespace Ray.Services
             }
         }
 
+        public void ShowRewarded(RewardedType type, Action onRewarded = null)
+        {
+            _onRewarded = onRewarded;
+            PlayRewardedAd(this, type);
+        }
+
         private void PlayRewardedAd(Component c, RewardedType type)
         {
             _rayDebug.Event("PlayRewardedAd", c, this);
@@ -176,6 +184,9 @@ namespace Ray.Services
                     _rayDebug.LogWarning($"Unknown reward type: {_currentRewarededType}", this);
                     break;
             }
+
+            _onRewarded?.Invoke();
+            _onRewarded = null;
         }
 
         private void OnRewardedAdLoadedEvent(string adUnitId, MaxSdkBase.AdInfo adInfo)

--- a/Scripts/BrickBlast/Popups/PreFailed.cs
+++ b/Scripts/BrickBlast/Popups/PreFailed.cs
@@ -16,8 +16,6 @@ using BlockPuzzleGameToolkit.Scripts.GUI;
 using BlockPuzzleGameToolkit.Scripts.System;
 using DG.Tweening;
 using TMPro;
-using BlockPuzzleGameToolkit.Scripts.Gameplay;
-using Ray.Services;
 
 namespace BlockPuzzleGameToolkit.Scripts.Popups
 {
@@ -33,23 +31,13 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
         protected int price;
         protected bool hasContinued = false;
 
-        private LevelManager levelManager;
-
         protected virtual void OnEnable()
         {
             price = GameManager.instance.GameSettings.continuePrice;
             continuePrice.text = price.ToString();
             continueButton.onClick.AddListener(Continue);
 
-            levelManager = FindObjectOfType<LevelManager>();
-            if (reviveButton != null)
-            {
-                reviveButton.onClick.AddListener(() =>
-                {
-                    Close();
-                    RewardedService.Instance.ShowRewarded(RewardedType.Revive);
-                });
-            }
+            RayBrickMediator.Instance?.SetReviveButton(reviveButton);
             
             InitializeTimer();
             

--- a/Scripts/BrickBlast/RayBrickMediator.cs
+++ b/Scripts/BrickBlast/RayBrickMediator.cs
@@ -4,11 +4,13 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using BlockPuzzleGameToolkit.Scripts.Gameplay;
+using BlockPuzzleGameToolkit.Scripts.GUI;
 
-public class RayBrickMediator : MonoBehaviour
-{
+    public class RayBrickMediator : MonoBehaviour
+    {
 
         public static RayBrickMediator Instance { get; private set; }
+        private CustomButton reviveButton;
 
         private void Awake()
         {
@@ -44,6 +46,29 @@ public class RayBrickMediator : MonoBehaviour
 
             if (Shop.Panel != null)
                 Shop.Panel.SetActive(false);
+        }
+
+        public void SetReviveButton(CustomButton button)
+        {
+            if (reviveButton != null)
+            {
+                reviveButton.onClick.RemoveListener(OnReviveButtonClicked);
+            }
+
+            reviveButton = button;
+
+            if (reviveButton != null)
+            {
+                reviveButton.onClick.RemoveListener(OnReviveButtonClicked);
+                reviveButton.onClick.AddListener(OnReviveButtonClicked);
+            }
+        }
+
+        private void OnReviveButtonClicked()
+        {
+            var levelManager = FindObjectOfType<LevelManager>();
+            RewardedService.Instance.ShowRewarded(RewardedType.Revive,
+                levelManager != null ? (System.Action)levelManager.ReviveCurrentStage : null);
         }
 
 


### PR DESCRIPTION
## Summary
- Delegate revive button binding to `RayBrickMediator` so ads trigger revive via `LevelManager`
- Add callback-supporting `ShowRewarded` in `RewardedService` and invoke callback after reward
- Simplify `PreFailed` revive handling to use mediator

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689d9a43ddb4832d962ee2e8a58f405b