### PR TITLE
Guard against missing OnWatchAdBtn

### DIFF
--- a/Ads/RewardedService.cs
+++ b/Ads/RewardedService.cs
@@ -129,7 +129,7 @@ namespace Ray.Services
         private void PlayRewardedAd(Component c, RewardedType type)
         {
             _rayDebug.Event("PlayRewardedAd", c, this);
-            EventService.Ad.OnWatchAdBtn.Invoke(this);
+            EventService.Ad.OnWatchAdBtn(this);
 
             _currentRewarededType = type;
 

--- a/Scripts/MyCode/Events/EventService.cs
+++ b/Scripts/MyCode/Events/EventService.cs
@@ -110,7 +110,7 @@ namespace Ray.Services
         {
             public UnityAction<Component> OnApplovinInitialized;
 
-            public UnityAction<Component> OnWatchAdBtn;
+            public UnityAction<Component> OnWatchAdBtn = delegate { };
 
             public UnityAction<Component> OnNoEnemiesWatched;
             public UnityAction<Component> OnReviveWatched;


### PR DESCRIPTION
## Summary
- Initialize OnWatchAdBtn with a default delegate to avoid null reference
- Invoke OnWatchAdBtn directly when playing rewarded ads

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689da7caa388832db5a029933c1678ca