### PR TITLE
Trigger revive event on rewarded ads

### DIFF
--- a/Ads/RewardedService.cs
+++ b/Ads/RewardedService.cs
@@ -169,7 +169,7 @@ namespace Ray.Services
                     EventService.Ad.OnNoEnemiesWatched?.Invoke(this);
                     break;
                 case RewardedType.Revive:
-                    
+                    EventService.Ad.OnReviveWatched?.Invoke(this);
                     break;
                 case RewardedType.Triple:
                     EventService.Ad.OnTripleWatched?.Invoke(this);


### PR DESCRIPTION
## Summary
- Fire `OnReviveWatched` when the revive rewarded ad is completed so revive listeners can act

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_689dbb5efb1c832d864845a85e5f772f