### PR TITLE
fix: guard back button initialization in ScrollableMapManager

### DIFF
--- a/Scripts/BrickBlast/Map/ScrollableMap/ScrollableMapManager.cs
+++ b/Scripts/BrickBlast/Map/ScrollableMap/ScrollableMapManager.cs
@@ -48,7 +48,14 @@ namespace BlockPuzzleGameToolkit.Scripts.Map.ScrollableMap
 
         private void Start()
         {
-            backButton.onClick.AddListener(SceneLoader.instance.GoMain);
+            if (backButton != null && SceneLoader.instance != null)
+            {
+                backButton.onClick.AddListener(SceneLoader.instance.GoMain);
+            }
+            else
+            {
+                Debug.LogError("BackButton or SceneLoader instance is not assigned.");
+            }
             var lvls = FindObjectsOfType<LevelPin>().OrderBy(x => x.groupIndex).ToArray();
             var lastGroup = GameDataManager.GetGroupIndex();
 


### PR DESCRIPTION
## Summary
- ensure Start checks for backButton and SceneLoader instance before adding listener

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a181efa868832db6e5d151002ad18b