### PR TITLE
Adjust win handling for sub-level progression

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -545,6 +545,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             if (subLevel < 3)
             {
                 GameDataManager.SetSubLevelIndex(subLevel + 1);
+                EventManager.GameStatus = EGameState.Playing;
                 GameManager.instance.OpenGame();
                 GameManager.instance.RestartLevel();
             }
@@ -553,7 +554,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                 int currentGroup = Mathf.CeilToInt(currentLevel / 3f);
                 GameDataManager.UnlockGroup(currentGroup + 1);
                 GameDataManager.ResetSubLevelIndex();
-                GameManager.instance.OpenMap();
+                EventManager.GameStatus = EGameState.PreWin;
             }
         }
 


### PR DESCRIPTION
## Summary
- Reset game state to `Playing` when advancing to sub-levels 2 and 3 to ensure immediate continuation
- Trigger `PreWin` state after completing sub-level 3 so `LevelStateHandler` can display win pop-up

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a191f4fff4832da88403f467b18383