### PR TITLE
Remove unused WinWaiting state

### DIFF
--- a/Scripts/BrickBlast/Enums/EGameState.cs
+++ b/Scripts/BrickBlast/Enums/EGameState.cs
@@ -23,7 +23,6 @@ namespace BlockPuzzleGameToolkit.Scripts.Enums
         PreWin,
         Loaded,
         Failed,
-        WinWaiting,
         Paused
     }
 }

--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -486,7 +486,9 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
         {
             if (gameMode != EGameMode.Classic && targetManager != null && targetManager.WillLevelBeComplete())
             {
-                EventManager.GameStatus = EGameState.WinWaiting;
+                // Avoid entering an intermediate WinWaiting state that is not
+                // handled by the level state machine. The win will be processed
+                // normally through SetWin() below.
             }
 
             yield return new WaitForSeconds(0.5f); // Keep a small delay for game flow
@@ -500,7 +502,6 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             // deck as a win and move to the next stage instead.
             if (availableShapes.Length == 0)
             {
-                EventManager.GameStatus = EGameState.WinWaiting;
                 yield return new WaitForSeconds(0.5f);
                 SetWin();
                 yield break;


### PR DESCRIPTION
## Summary
- avoid unhandled WinWaiting state during win checks
- remove WinWaiting enum value

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a193887ae4832dbe97fda799d0f866