### PR TITLE
Prevent deck refill after win

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -502,7 +502,12 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             // deck as a win and move to the next stage instead.
             if (availableShapes.Length == 0)
             {
-                yield return new WaitForSeconds(0.5f);
+                // Move immediately to the pre-win state so that no further
+                // actions (like deck refills) are triggered while we prepare to
+                // finish the level. A brief yield allows the state change to
+                // propagate before SetWin() executes.
+                EventManager.GameStatus = EGameState.PreWin;
+                yield return null;
                 SetWin();
                 yield break;
             }


### PR DESCRIPTION
## Summary
- Transition to `PreWin` state immediately when the deck is empty to avoid further refills
- Wait a frame before invoking `SetWin` to finalize the victory

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 errors accessing package repositories)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a19566d984832daac52a1487f01a11