### PR TITLE
Add timed mode level asset

### DIFF
--- a/Resources.meta
+++ b/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cb327b2451124bc6846c247fb58790bd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Resources/Misc.meta
+++ b/Resources/Misc.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9d879bd9ddb04f659d45466c26a06eac
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Resources/Misc/TimeLevel.asset
+++ b/Resources/Misc/TimeLevel.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4a5c42505bd4683b56b6baff710ae0a, type: 3}
+  m_Name: TimeLevel
+  m_EditorClassIdentifier:
+  rows: 8
+  columns: 8
+  levelRows: []
+  levelType: {fileID: 0}
+  enableTimer: 1
+  timerDuration: 120
+  bonusItemColors: {}
+  targetInstance: []
+  emptyCellPercentage: 10

--- a/Resources/Misc/TimeLevel.asset.meta
+++ b/Resources/Misc/TimeLevel.asset.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 901fe134700b43f2b030434eb05f36e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add `TimeLevel` scriptable asset for timed mode under `Resources/Misc`
- configure timer settings for timed mode levels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a1a8ac8508832db47d679b5b984130