### PR TITLE
Allow rewarded ads to replenish boosters

### DIFF
--- a/Scripts/BrickBlast/RayBrickMediator.cs
+++ b/Scripts/BrickBlast/RayBrickMediator.cs
@@ -11,6 +11,8 @@ using BlockPuzzleGameToolkit.Scripts.Gameplay;
         public static RayBrickMediator Instance { get; private set; }
         public Button reviveButton;
 
+        [SerializeField] private Sprite boosterAdSprite;
+
         private void Awake()
         {
             Instance = this;
@@ -138,7 +140,10 @@ using BlockPuzzleGameToolkit.Scripts.Gameplay;
             if (obj == null) return;
 
             var button = obj.GetComponent<Button>();
-            if (button == null) return;
+            var image = obj.GetComponent<Image>();
+            if (button == null || image == null) return;
+
+            var originalSprite = image.sprite;
 
             button.onClick.RemoveAllListeners();
             button.onClick.AddListener(() =>
@@ -162,7 +167,20 @@ using BlockPuzzleGameToolkit.Scripts.Gameplay;
 
                 if (count <= 0)
                 {
-                    EventService.UI.OnToggleInsufficient?.Invoke(this);
+                    if (RewardedService.Instance.IsRewardedReady(RewardedType.ExtraSpace))
+                    {
+                        image.sprite = boosterAdSprite;
+                        RewardedService.Instance.ShowRewarded(RewardedType.ExtraSpace, () =>
+                        {
+                            image.sprite = originalSprite;
+                            ResourceService.Instance?.RewardBooster(type);
+                            RefreshShop(this);
+                        });
+                    }
+                    else
+                    {
+                        EventService.UI.OnToggleInsufficient?.Invoke(this);
+                    }
                     return;
                 }
 
@@ -204,7 +222,7 @@ using BlockPuzzleGameToolkit.Scripts.Gameplay;
             {
                 var button = levelButton.GetComponent<Button>();
                 if (button != null)
-                    button.interactable = amount > 0;
+                    button.interactable = amount > 0 || RewardedService.Instance.IsRewardedReady(RewardedType.ExtraSpace);
             }
 
             Shop.ClearRow.Price = CalculateBoosterPrice(Database.UserData.Stats.Power_1);

--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -50,7 +50,7 @@ namespace Ray.Services
             EventService.Ad.OnNoEnemiesWatched += RewardNoEnemies;
             EventService.Ad.OnTripleWatched += RewardEndTriple;
 
-            EventService.Ad.OnExtraSpaceWatched += RewardExtraSpace;
+            // ExtraSpace rewarded ads are repurposed for boosters, so no listener here
 
             EventService.Brd.OnFirstTimeConsent += RewardBrightData;
         }
@@ -163,6 +163,31 @@ namespace Ray.Services
             }
 
             saveData.Stats.TotalCurrency -= cost;
+
+            await Database.Instance.Save(saveData);
+
+            EventService.Resource.OnMenuResourceChanged.Invoke(this);
+        }
+
+        public async void RewardBooster(BoosterType type)
+        {
+            var saveData = Database.UserData.Copy();
+
+            switch (type)
+            {
+                case BoosterType.ClearRow:
+                    saveData.Stats.Power_1 = Mathf.Clamp(saveData.Stats.Power_1 + 1, 0, 99);
+                    break;
+                case BoosterType.ClearColumn:
+                    saveData.Stats.Power_2 = Mathf.Clamp(saveData.Stats.Power_2 + 1, 0, 99);
+                    break;
+                case BoosterType.ClearSquare:
+                    saveData.Stats.Power_3 = Mathf.Clamp(saveData.Stats.Power_3 + 1, 0, 99);
+                    break;
+                case BoosterType.ChangeShape:
+                    saveData.Stats.Power_4 = Mathf.Clamp(saveData.Stats.Power_4 + 1, 0, 99);
+                    break;
+            }
 
             await Database.Instance.Save(saveData);
 


### PR DESCRIPTION
## Summary
- add booster ad sprite handling and ad flow when booster count is zero
- save booster reward after ad and refresh UI
- remove unused extra-space ad listener

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a1b771e7ec832d9b495d87e1ccfa45