### PR TITLE
Persist classic mode leaderboard entries

### DIFF
--- a/Scripts/BrickBlast/Gameplay/ClassicModeHandler.cs
+++ b/Scripts/BrickBlast/Gameplay/ClassicModeHandler.cs
@@ -3,6 +3,7 @@ using BlockPuzzleGameToolkit.Scripts.System;
 using BlockPuzzleGameToolkit.Scripts.Enums;
 using UnityEngine;
 using UnityEngine.UI;
+using Ray.Services;
 
 namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 {
@@ -58,6 +59,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             if (score > bestScore)
             {
                 ResourceManager.instance.GetResource("Score").Set(score);
+                int userLevel = Database.UserData.Level;
+                LeaderboardService.Instance.UpdateClassicLeaderboard(score, userLevel);
             }
 
             base.OnLose();

--- a/Scripts/MyCode/Database/Database.cs
+++ b/Scripts/MyCode/Database/Database.cs
@@ -20,6 +20,7 @@ namespace Ray.Services
 
         private FirebaseFirestore _firestore;
         private string _userID;
+        public string UserId => _userID;
         private readonly SemaphoreSlim _saveSemaphore = new SemaphoreSlim(1, 1);
 
         private RayDebugService _rayDebug => ServiceAllocator.Instance.GetDebugService(ConfigType.Services);

--- a/Scripts/MyCode/Services/LeaderboardService.cs
+++ b/Scripts/MyCode/Services/LeaderboardService.cs
@@ -1,0 +1,34 @@
+using Firebase.Firestore;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Ray.Services
+{
+    public class LeaderboardService : MonoBehaviour
+    {
+        public static LeaderboardService Instance;
+
+        private void Awake()
+        {
+            Instance = this;
+        }
+
+        public async void UpdateClassicLeaderboard(int score, int level)
+        {
+            string userId = Database.Instance.UserId;
+
+            var data = new Dictionary<string, object>
+            {
+                { "Score", score },
+                { "Level", level }
+            };
+
+            await FirebaseFirestore.DefaultInstance
+                .Collection("Leaderboards")
+                .Document(userId)
+                .SetAsync(data);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- expose authenticated user ID via Database
- add LeaderboardService to store classic scores in Firestore
- update ClassicModeHandler to write high scores to leaderboard

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a43adb6dd8832d946648a50b6a1fe2