### PR TITLE
Add Firestore leaderboards for classic mode

### DIFF
--- a/Scripts/BrickBlast/Gameplay/ClassicModeHandler.cs
+++ b/Scripts/BrickBlast/Gameplay/ClassicModeHandler.cs
@@ -3,6 +3,7 @@ using BlockPuzzleGameToolkit.Scripts.System;
 using BlockPuzzleGameToolkit.Scripts.Enums;
 using UnityEngine;
 using UnityEngine.UI;
+using Ray.Services;
 
 namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 {
@@ -58,6 +59,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             if (score > bestScore)
             {
                 ResourceManager.instance.GetResource("Score").Set(score);
+                _ = Leaderboards.UpdateClassicLeaderboard(score, Database.UserData.Level);
             }
 
             base.OnLose();

--- a/Scripts/MyCode/Database/Leaderboards.cs
+++ b/Scripts/MyCode/Database/Leaderboards.cs
@@ -1,0 +1,39 @@
+using Firebase.Auth;
+using Firebase.Firestore;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Ray.Services
+{
+    public static class Leaderboards
+    {
+        private static FirebaseFirestore Firestore => FirebaseFirestore.DefaultInstance;
+
+        public static async Task UpdateClassicLeaderboard(int score, int level)
+        {
+            try
+            {
+                var auth = FirebaseAuth.DefaultInstance;
+                if (auth.CurrentUser == null)
+                {
+                    Debug.LogWarning("Leaderboards: no authenticated user.");
+                    return;
+                }
+
+                var docRef = Firestore.Collection("Leaderboards").Document(auth.CurrentUser.UserId);
+                var data = new Dictionary<string, object>
+                {
+                    { "Score", score },
+                    { "Level", level }
+                };
+
+                await docRef.SetAsync(data, SetOptions.MergeAll);
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogError($"Leaderboards: failed to update leaderboard - {e}");
+            }
+        }
+    }
+}

--- a/Scripts/MyCode/Database/Leaderboards.cs.meta
+++ b/Scripts/MyCode/Database/Leaderboards.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d3c38a7423454d9f8b222f779321d540


### PR DESCRIPTION
## Summary
- add Leaderboards service to sync high scores and level data to Firestore
- update ClassicModeHandler to submit new high scores to Firestore leaderboards

## Testing
- `dotnet build` (fails: command not found)
- `apt-get update` (fails: repository not signed)


------
https://chatgpt.com/codex/tasks/task_b_68a43bfdc7c4832db593592eb3382a13