### PR TITLE
Fix level calculation using group index

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -309,11 +309,11 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                 if (gameMode == EGameMode.Classic)
                 {
                     _levelData = Resources.Load<Level>("Misc/ClassicLevel");
-                    currentLevel = Database.UserData.Level;
+                    currentLevel = GameDataManager.GetLevelNum();
                 }
                 else
                 {
-                    currentLevel = Database.UserData.Level;
+                    currentLevel = GameDataManager.GetLevelNum();
                     _levelData = Resources.Load<Level>("Levels/Level_" + currentLevel);
                 }
             }
@@ -554,9 +554,9 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 
             EventService.Player.OnParked?.Invoke(this);
 
-            int nextLevel = Database.UserData.Level + 1;
-            Database.UserData.SetLevel(nextLevel);
-            GameDataManager.LevelNum = nextLevel;
+            int currentLevelGlobal = GameDataManager.GetLevelNum();
+            int nextLevelGlobal = currentLevelGlobal + 1;
+            GameDataManager.SetLevelNum(nextLevelGlobal);
             GameDataManager.SetLevel(null);
 
             int subLevel = GameDataManager.GetSubLevelIndex();

--- a/Scripts/BrickBlast/Popups/MainMenu.cs
+++ b/Scripts/BrickBlast/Popups/MainMenu.cs
@@ -47,7 +47,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
             settingsButton.onClick.AddListener(SettingsButtonClicked);
             luckySpin.onClick.AddListener(LuckySpinButtonClicked);
             UpdateFreeSpinMarker();
-            GameDataManager.LevelNum = Ray.Services.Database.UserData.Level;
+            GameDataManager.LevelNum = GameDataManager.GetLevelNum();
             var levelsCount = Resources.LoadAll<Level>("Levels").Length;
             luckySpin.gameObject.SetActive(GameManager.instance.GameSettings.enableLuckySpin);
             if(!GameManager.instance.GameSettings.enableTimedMode)

--- a/Scripts/BrickBlast/System/GameDataManager.cs
+++ b/Scripts/BrickBlast/System/GameDataManager.cs
@@ -73,11 +73,10 @@ namespace BlockPuzzleGameToolkit.Scripts.System
 
         public static void UnlockLevel(int currentLevel)
         {
-            int savedLevel = Database.UserData.Level;
+            int savedLevel = GetLevelNum();
             if (savedLevel < currentLevel)
             {
-                LevelNum = currentLevel;
-                Database.UserData.SetLevel(currentLevel);
+                SetLevelNum(currentLevel);
             }
         }
 
@@ -92,7 +91,7 @@ namespace BlockPuzzleGameToolkit.Scripts.System
 
         public static int GetLevelNum()
         {
-            return Database.UserData.Level;
+            return (Database.UserData.GroupIndex - 1) * 3 + Database.UserData.Level;
         }
 
         public static int GetGroupIndex()
@@ -154,8 +153,10 @@ namespace BlockPuzzleGameToolkit.Scripts.System
         public static void SetAllLevelsCompleted()
         {
             var levels = Resources.LoadAll<Level>("Levels").Length;
-            Database.UserData.SetLevel(levels);
-            Database.UserData.SetGroupIndex(Mathf.CeilToInt(levels / 3f));
+            int groupIndex = Mathf.CeilToInt(levels / 3f);
+            int levelInGroup = levels - (groupIndex - 1) * 3;
+            Database.UserData.SetGroupIndex(groupIndex);
+            Database.UserData.SetLevel(levelInGroup);
         }
 
         internal static bool HasMoreLevels()
@@ -168,7 +169,10 @@ namespace BlockPuzzleGameToolkit.Scripts.System
         public static void SetLevelNum(int stateCurrentLevel)
         {
             LevelNum = stateCurrentLevel;
-            Database.UserData.SetLevel(stateCurrentLevel);
+            int groupIndex = Mathf.CeilToInt(stateCurrentLevel / 3f);
+            int levelInGroup = stateCurrentLevel - (groupIndex - 1) * 3;
+            Database.UserData.SetGroupIndex(groupIndex);
+            Database.UserData.SetLevel(levelInGroup);
         }
     }
 }

--- a/Scripts/BrickBlast/System/GameManager.cs
+++ b/Scripts/BrickBlast/System/GameManager.cs
@@ -206,7 +206,7 @@ namespace BlockPuzzleGameToolkit.Scripts.System
 
         public void NextLevel()
         {
-            GameDataManager.LevelNum++;
+            GameDataManager.SetLevelNum(GameDataManager.GetLevelNum() + 1);
             OpenGame();
             RestartLevel();
         }


### PR DESCRIPTION
## Summary
- derive global level from group index and level
- load and advance levels using global stage numbers
- update menu and manager to handle new level computation

## Testing
- ⚠️ `dotnet test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a582caa3b8832db230c9a6de188d99