### PR TITLE
Handle timed mode level loading

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -311,6 +311,10 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                     _levelData = Resources.Load<Level>("Misc/ClassicLevel");
                     currentLevel = GameDataManager.GetLevelNum();
                 }
+                else if (gameMode == EGameMode.Timed)
+                {
+                    _levelData = GameDataManager.GetLevel();
+                }
                 else
                 {
                     currentLevel = GameDataManager.GetLevelNum();
@@ -323,8 +327,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                 return;
             }
 
-            // Apply global time settings if timed mode is enabled
-            if (GameManager.instance.GameSettings.enableTimedMode && _levelData.enableTimer)
+            // Apply global time settings if timed mode is enabled (non-timed modes only)
+            if (gameMode != EGameMode.Timed && GameManager.instance.GameSettings.enableTimedMode && _levelData.enableTimer)
             {
                 timerDuration = _levelData.timerDuration;
                 if(_levelData.timerDuration == 0)
@@ -334,6 +338,15 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             FindObjectsOfType<MonoBehaviour>().OfType<IBeforeLevelLoadable>().ToList().ForEach(x => x.OnLevelLoaded(_levelData));
             LoadLevel(_levelData);
             FindObjectsOfType<MonoBehaviour>().OfType<ILevelLoadable>().ToList().ForEach(x => x.OnLevelLoaded(_levelData));
+
+            if (gameMode == EGameMode.Timed)
+            {
+                timedModeHandler = FindObjectOfType<TimedModeHandler>();
+                EventManager.GameStatus = EGameState.Playing;
+                timedModeHandler?.ResumeGame();
+                return;
+            }
+
             Invoke(nameof(StartGame), 0.5f);
             if (GameManager.instance.IsTutorialMode())
             {


### PR DESCRIPTION
## Summary
- Skip level-oriented start in `LevelManager.Load`
- Resume `TimedModeHandler` and enter playing state directly for timed mode

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_68a58f51edb0832daea867df4cf4d314