### PR TITLE
fix: load correct level for timed mode

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -311,6 +311,11 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                     _levelData = Resources.Load<Level>("Misc/ClassicLevel");
                     currentLevel = Database.UserData.Level;
                 }
+                else if (gameMode == EGameMode.Timed)
+                {
+                    _levelData = Resources.Load<Level>("Misc/TimeLevel");
+                    currentLevel = 0;
+                }
                 else
                 {
                     currentLevel = Database.UserData.Level;


### PR DESCRIPTION
## Summary
- load specific TimeLevel when starting timed mode
- revert adventure item factory to original logic

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a592fe8828832d8118510cfe0d4b45