### PR TITLE
Reset level cache when changing game modes to fix timed mode

### DIFF
--- a/Scripts/BrickBlast/System/GameDataManager.cs
+++ b/Scripts/BrickBlast/System/GameDataManager.cs
@@ -148,6 +148,7 @@ namespace BlockPuzzleGameToolkit.Scripts.System
         {
             PlayerPrefs.SetInt("GameMode", (int)gameMode);
             PlayerPrefs.Save();
+            _level = null;
         }
 
         public static void SetAllLevelsCompleted()


### PR DESCRIPTION
## Summary
- Clear cached level data when switching game modes to ensure timed mode loads the dedicated time level instead of the last adventure stage

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_b_68a5958dbdd8832db572e702583f6fc6