### PR TITLE
Reset level cache when changing game modes to fix timed mode

### DIFF
--- a/Scripts/BrickBlast/Gameplay/ItemFactoryAdventure.cs
+++ b/Scripts/BrickBlast/Gameplay/ItemFactoryAdventure.cs
@@ -20,6 +20,12 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
     {
         public void OnLevelLoaded(Level level)
         {
+            if (level?.levelType == null)
+            {
+                _oneColorMode = false;
+                return;
+            }
+
             _oneColorMode = level.levelType.singleColorMode;
             if (_oneColorMode)
             {

--- a/Scripts/BrickBlast/System/GameDataManager.cs
+++ b/Scripts/BrickBlast/System/GameDataManager.cs
@@ -148,6 +148,7 @@ namespace BlockPuzzleGameToolkit.Scripts.System
         {
             PlayerPrefs.SetInt("GameMode", (int)gameMode);
             PlayerPrefs.Save();
+            _level = null;
         }
 
         public static void SetAllLevelsCompleted()


### PR DESCRIPTION
## Summary
- Clear cached level data when switching game modes so timed mode loads its dedicated level
- Guard `ItemFactoryAdventure` against timed levels lacking a level type to prevent null reference errors

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_b_68a5958dbdd8832db572e702583f6fc6