### PR TITLE
fix: prevent null reference when generating field

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/FieldManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/FieldManager.cs
@@ -35,13 +35,14 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 
         public void Generate(Level level)
         {
-            var oneColorMode = level.levelType.singleColorMode;
-
             if (level == null)
             {
                 Debug.LogError("Attempted to generate field with null level");
                 return;
             }
+
+            // If levelType is not assigned, default to false to avoid null references
+            var oneColorMode = level.levelType != null && level.levelType.singleColorMode;
 
             GenerateField(level.rows, level.columns);
 


### PR DESCRIPTION
## Summary
- ensure FieldManager.Generate checks for null level data
- avoid null reference when LevelType is missing by safely evaluating `singleColorMode`

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68a5ab4a06a4832dadcf2ede3b0b8d67