### PR TITLE
fix: handle null level data in field and target managers

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/FieldManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/FieldManager.cs
@@ -35,13 +35,14 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 
         public void Generate(Level level)
         {
-            var oneColorMode = level.levelType.singleColorMode;
-
             if (level == null)
             {
                 Debug.LogError("Attempted to generate field with null level");
                 return;
             }
+
+            // If levelType is not assigned, default to false to avoid null references
+            var oneColorMode = level.levelType != null && level.levelType.singleColorMode;
 
             GenerateField(level.rows, level.columns);
 

--- a/Scripts/BrickBlast/Gameplay/Managers/TargetManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/TargetManager.cs
@@ -109,7 +109,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             if (!GameManager.instance.IsTutorialMode())
             {
                 var t = Instantiate(targetPanel, targetParent);
-                t.OnLevelLoaded(level.levelType.elevelType);
+                var levelType = level.levelType?.elevelType ?? ELevelType.Score;
+                t.OnLevelLoaded(levelType);
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure `FieldManager.Generate` checks for null level data
- avoid null reference when `LevelType` is missing by safely evaluating `singleColorMode`
- guard `TargetManager.OnLevelLoaded` against missing `LevelType`

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68a5ab4a06a4832dadcf2ede3b0b8d67