### PR TITLE
Auto-continue when pre-fail timer expires

### DIFF
--- a/Scripts/BrickBlast/Popups/Failed.cs
+++ b/Scripts/BrickBlast/Popups/Failed.cs
@@ -29,8 +29,15 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
 
         protected virtual void OnEnable()
         {
-            retryButton.onClick.AddListener(Retry);
-            closeButton.onClick.AddListener(CollectAndExit);
+            if (retryButton != null)
+            {
+                retryButton.onClick.AddListener(Retry);
+            }
+
+            if (closeButton != null)
+            {
+                closeButton.onClick.AddListener(CollectAndExit);
+            }
 
             if (currencyText != null)
             {

--- a/Scripts/BrickBlast/Popups/PreFailed.cs
+++ b/Scripts/BrickBlast/Popups/PreFailed.cs
@@ -88,8 +88,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
                 hasContinued = true;
 
                 CancelInvoke(nameof(UpdateTimer));
-                EventManager.GameStatus = EGameState.Failed;
-                Close();
+                StopInteration();
+                OnContinue();
             }
         }
 


### PR DESCRIPTION
## Summary
- Trigger continue flow automatically when pre-fail timer reaches zero
- Guard failed popup buttons against missing references

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a5b737a6c4832dae276fa214075d80