### PR TITLE
Handle stage counter in LevelManager

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -64,6 +64,9 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
         [SerializeField]
         private GameObject timerPanel;
 
+        [SerializeField]
+        private TextMeshProUGUI stageCounterText;
+
         public EGameMode gameMode;
         public Level _levelData;
 
@@ -147,6 +150,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                 RestoreGameState();
             else if (gameMode == EGameMode.Timed)
                 RestoreTimedGameState();
+
+            UpdateStageCounter();
         }
 
         private void RestoreGameState()
@@ -358,13 +363,20 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                 }
             }
 
-            RayBrickMediator.Instance?.UpdateStageCounter();
         }
 
         private void StartGame()
         {
             EventManager.GameStatus = EGameState.PrepareGame;
             classicModeHandler = FindObjectOfType<ClassicModeHandler>();
+        }
+
+        private void UpdateStageCounter()
+        {
+            if (stageCounterText != null)
+            {
+                stageCounterText.text = $"{GameDataManager.GetSubLevelIndex()}/3";
+            }
         }
 
         private void LoadLevel(Level levelData)

--- a/Scripts/BrickBlast/RayBrickMediator.cs
+++ b/Scripts/BrickBlast/RayBrickMediator.cs
@@ -17,7 +17,6 @@ using System.Collections.Generic;
         public Button winCollectButton;
         public Button winTripleButton;
         public TextMeshProUGUI winCurrencyText;
-        public TextMeshProUGUI stageCounterText;
         private bool winRewardGranted;
 
         [SerializeField] private Sprite boosterAdSprite;
@@ -119,14 +118,6 @@ using System.Collections.Generic;
             {
                 winTripleButton.onClick.AddListener(OnWinTripleClicked);
                 winTripleButton.interactable = RewardedService.Instance.IsRewardedReady(RewardedType.Triple);
-            }
-        }
-
-        public void UpdateStageCounter()
-        {
-            if (stageCounterText != null)
-            {
-                stageCounterText.text = $"{GameDataManager.GetSubLevelIndex()}/3";
             }
         }
 


### PR DESCRIPTION
## Summary
- manage stage counter text from LevelManager with dedicated field and update method
- strip stage counter handling from PreFailed popup

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68a5b83178a8832db635ec82714aff49