### PR TITLE
Reset adventure level to first stage on fail without group change

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.State.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.State.cs
@@ -12,6 +12,7 @@
 
 using BlockPuzzleGameToolkit.Scripts.Enums;
 using BlockPuzzleGameToolkit.Scripts.System;
+using Ray.Services;
 
 namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 {
@@ -46,7 +47,12 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                 int groupIndex = (currentLevel - 1) / 3;
                 int newLevel = groupIndex * 3 + 1;
                 currentLevel = newLevel;
-                GameDataManager.SetLevelNum(newLevel);
+
+                GameDataManager.LevelNum = newLevel;
+                Database.UserData.Level = newLevel;
+                var saveData = Database.UserData.Copy();
+                Database.Instance?.Save(saveData);
+
                 GameDataManager.ResetSubLevelIndex();
                 GameDataManager.SetLevel(null);
                 GameManager.instance.RestartLevel();

--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -630,7 +630,12 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             cellDeck.UpdateCellDeckAfterFail();
 
             currentLevel = failedLevel;
-            GameDataManager.SetLevelNum(failedLevel);
+
+            GameDataManager.LevelNum = failedLevel;
+            Database.UserData.Level = failedLevel;
+            var saveData = Database.UserData.Copy();
+            Database.Instance?.Save(saveData);
+
             GameDataManager.SetSubLevelIndex(failedSubLevelIndex);
             GameDataManager.SetLevel(null);
             GameManager.instance.RestartLevel();

--- a/Scripts/BrickBlast/Popups/PreFailed.cs
+++ b/Scripts/BrickBlast/Popups/PreFailed.cs
@@ -18,6 +18,7 @@ using DG.Tweening;
 using TMPro;
 using UnityEngine.InputSystem.HID;
 using UnityEngine.UI;
+using Ray.Services;
 
 namespace BlockPuzzleGameToolkit.Scripts.Popups
 {
@@ -134,7 +135,24 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
         private async void ContinueGame()
         {
             result = EPopupResult.Continue;
-            await Ray.Services.Database.UserData.AddScoreAsCurrency(GameManager.instance.Score);
+            await Database.UserData.AddScoreAsCurrency(GameManager.instance.Score);
+
+            if (GameDataManager.GetGameMode() == EGameMode.Adventure)
+            {
+                int currentLevel = Database.UserData.Level;
+                int groupStart = ((currentLevel - 1) / 3) * 3 + 1;
+                if (currentLevel != groupStart)
+                {
+                    GameDataManager.LevelNum = groupStart;
+                    Database.UserData.Level = groupStart;
+                    var saveData = Database.UserData.Copy();
+                    Database.Instance?.Save(saveData);
+                }
+
+                GameDataManager.ResetSubLevelIndex();
+                GameDataManager.SetLevel(null);
+            }
+
             GameManager.instance.MainMenu();
             Close();
         }


### PR DESCRIPTION
## Summary
- Reset adventure mode to the first sublevel on failure without advancing group index
- Preserve group index when reviving a failed stage
- Ensure continue action resets adventure level data to group's first stage

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a5c9a8d6ec832dbc90b69b7ce4426a