### PR TITLE
Fix adventure mode level calculation

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -313,8 +313,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                 }
                 else
                 {
-                    currentLevel = Database.UserData.Level;
-                    _levelData = Resources.Load<Level>("Levels/Level_" + currentLevel);
+                    currentLevel = GameDataManager.GetLevelNum();
+                    _levelData = GameDataManager.GetLevel();
                 }
             }
             if (_levelData == null)

--- a/Scripts/BrickBlast/System/GameDataManager.cs
+++ b/Scripts/BrickBlast/System/GameDataManager.cs
@@ -92,7 +92,13 @@ namespace BlockPuzzleGameToolkit.Scripts.System
 
         public static int GetLevelNum()
         {
-            return Database.UserData.Level;
+            var level = Database.UserData.Level;
+            if (GetGameMode() == EGameMode.Adventure)
+            {
+                var groupIndex = Database.UserData.GroupIndex;
+                level += (groupIndex - 1) * 3;
+            }
+            return level;
         }
 
         public static int GetGroupIndex()


### PR DESCRIPTION
## Summary
- compute adventure mode level from group index
- load adventure levels using computed level

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a6c20826ac832da761319fb451af11