### PR TITLE
Fix timed mode loading

### DIFF
--- a/Scripts/BrickBlast/System/GameDataManager.cs
+++ b/Scripts/BrickBlast/System/GameDataManager.cs
@@ -155,6 +155,8 @@ namespace BlockPuzzleGameToolkit.Scripts.System
         {
             PlayerPrefs.SetInt("GameMode", (int)gameMode);
             PlayerPrefs.Save();
+            // Clear cached level so the appropriate level for the new game mode is loaded
+            _level = null;
         }
 
         public static void SetAllLevelsCompleted()


### PR DESCRIPTION
## Summary
- clear cached level when switching game modes so timed mode uses TimeLevel asset

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a6cb2f3160832db38e3d710296af61