### PR TITLE
Link TimeLevel asset to classic level type

### DIFF
--- a/Resources/Misc/ClassicLevelType.asset
+++ b/Resources/Misc/ClassicLevelType.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 38e0a7b181df4ac392d6eab85851bb80, type: 3}
+  m_Name: ClassicLevelType
+  m_EditorClassIdentifier:
+  elevelType: 2
+  targets: []
+  prePlayPopup: {fileID: 0}
+  preFailedPopup: {fileID: 0}
+  failedPopup: {fileID: 0}
+  preWinPopup: {fileID: 0}
+  winPopup: {fileID: 0}
+  selectable: 1
+  singleColorMode: 1
+  stateHandler: {fileID: 0}

--- a/Resources/Misc/ClassicLevelType.asset.meta
+++ b/Resources/Misc/ClassicLevelType.asset.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 432a203465804500904d70249e96feaa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Resources/Misc/TimeLevel.asset
+++ b/Resources/Misc/TimeLevel.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   rows: 8
   columns: 8
   levelRows: []
-  levelType: {fileID: 0}
+  levelType: {fileID: 11400000, guid: 432a203465804500904d70249e96feaa, type: 2}
   enableTimer: 1
   timerDuration: 120
   bonusItemColors: {}


### PR DESCRIPTION
## Summary
- Link TimeLevel asset to Classic LevelTypeScriptable so timed mode has valid levelType
- Introduce ClassicLevelType asset representing ELevelType.Classic

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a6d2cae12c832daeb1008a2b2a5681