### PR TITLE
Handle missing levelType during level load

### DIFF
--- a/Scripts/BrickBlast/Gameplay/ItemFactoryAdventure.cs
+++ b/Scripts/BrickBlast/Gameplay/ItemFactoryAdventure.cs
@@ -20,7 +20,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
     {
         public void OnLevelLoaded(Level level)
         {
-            _oneColorMode = level.levelType.singleColorMode;
+            _oneColorMode = level.levelType != null && level.levelType.singleColorMode;
             if (_oneColorMode)
             {
                 _oneColor = Random.Range(1, items.Length);


### PR DESCRIPTION
## Summary
- Guard against null `levelType` when loading levels to disable one-color mode by default

## Testing
- `mcs Scripts/BrickBlast/Gameplay/ItemFactoryAdventure.cs` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a6d438eea4832dabed249ad4190753