### PR TITLE
Ensure timed levels start in playing state

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.State.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.State.cs
@@ -20,11 +20,17 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
         private void HandleGameStateChange(EGameState newState)
         {
             var currentLevel = GetCurrentLevel();
-            var stateHandler = currentLevel.levelType.stateHandler;
+            var levelType = currentLevel != null ? currentLevel.levelType : null;
+            var stateHandler = levelType != null ? levelType.stateHandler : null;
 
             if (stateHandler != null)
             {
                 stateHandler.HandleState(newState, this);
+            }
+            else if (gameMode == EGameMode.Timed && newState == EGameState.PrepareGame)
+            {
+                EventManager.GameStatus = EGameState.Playing;
+                return;
             }
 
             if (newState == EGameState.Failed)

--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -366,7 +366,15 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 
         private void StartGame()
         {
-            EventManager.GameStatus = EGameState.PrepareGame;
+            if (gameMode == EGameMode.Timed)
+            {
+                EventManager.GameStatus = EGameState.Playing;
+            }
+            else
+            {
+                EventManager.GameStatus = EGameState.PrepareGame;
+            }
+
             classicModeHandler = FindObjectOfType<ClassicModeHandler>();
         }
 


### PR DESCRIPTION
## Summary
- Start timed mode directly in `Playing` state instead of waiting for a level type handler
- Guard against missing `levelType` by defaulting to `Playing`

## Testing
- `dotnet test` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a6d5e0327c832d9aa6054d1a3d8c9f