### PR TITLE
Ensure timed mode displays fail popup

### DIFF
--- a/Scripts/BrickBlast/LevelsData/LevelStateHandler.cs
+++ b/Scripts/BrickBlast/LevelsData/LevelStateHandler.cs
@@ -59,6 +59,13 @@ namespace BlockPuzzleGameToolkit.Scripts.LevelsData
             {
                 MenuManager.instance.ShowPopup(failedPopup);
             }
+            else if (levelManager.gameMode == EGameMode.Timed)
+            {
+                // Timed levels sometimes lack a failed popup on the LevelType,
+                // leaving the game stuck on the gameplay screen. Fall back to
+                // the default timed failure popup in that case.
+                MenuManager.instance.ShowPopup<FailedTimed>();
+            }
         }
 
         private protected virtual void HandlePreWin(LevelManager levelManager)


### PR DESCRIPTION
## Summary
- Show fallback timed fail popup only for timed mode when no popup is set on LevelType

## Testing
- ❌ `dotnet test` *(command not found)*
- ❌ `npm test` *(missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aadaf94cf8832db26414c54db99476