### PR TITLE
Ensure timed mode displays fail popup

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.State.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.State.cs
@@ -12,6 +12,7 @@
 
 using BlockPuzzleGameToolkit.Scripts.Enums;
 using BlockPuzzleGameToolkit.Scripts.System;
+using BlockPuzzleGameToolkit.Scripts.Popups;
 
 namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 {
@@ -27,10 +28,20 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             {
                 stateHandler.HandleState(newState, this);
             }
-            else if (gameMode == EGameMode.Timed && newState == EGameState.PrepareGame)
+            else if (gameMode == EGameMode.Timed)
             {
-                EventManager.GameStatus = EGameState.Playing;
-                return;
+                switch (newState)
+                {
+                    case EGameState.PrepareGame:
+                        EventManager.GameStatus = EGameState.Playing;
+                        return;
+                    case EGameState.PreFailed:
+                        EventManager.GameStatus = EGameState.Failed;
+                        return;
+                    case EGameState.Failed:
+                        MenuManager.instance.ShowPopup<FailedTimed>();
+                        break;
+                }
             }
 
             if (newState == EGameState.Failed)

--- a/Scripts/BrickBlast/LevelsData/LevelStateHandler.cs
+++ b/Scripts/BrickBlast/LevelsData/LevelStateHandler.cs
@@ -59,6 +59,13 @@ namespace BlockPuzzleGameToolkit.Scripts.LevelsData
             {
                 MenuManager.instance.ShowPopup(failedPopup);
             }
+            else if (levelManager.gameMode == EGameMode.Timed)
+            {
+                // Timed levels sometimes lack a failed popup on the LevelType,
+                // leaving the game stuck on the gameplay screen. Fall back to
+                // the default timed failure popup in that case.
+                MenuManager.instance.ShowPopup<FailedTimed>();
+            }
         }
 
         private protected virtual void HandlePreWin(LevelManager levelManager)


### PR DESCRIPTION
## Summary
- Show fallback timed fail popup only for timed mode when no popup is set on LevelType
- Force timed levels without a state handler to advance to failed state and show default fail popup

## Testing
- ❌ `dotnet test` *(command not found)*
- ❌ `npm test` *(missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aadaf94cf8832db26414c54db99476