### PR TITLE
Load FailedTimed popup via RayBrickMediator

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.State.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.State.cs
@@ -39,7 +39,15 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                         EventManager.GameStatus = EGameState.Failed;
                         return;
                     case EGameState.Failed:
-                        MenuManager.instance.ShowPopup<FailedTimed>();
+                        var failedTimedPrefab = RayBrickMediator.Instance?.FailedTimedPopup;
+                        if (failedTimedPrefab != null)
+                        {
+                            MenuManager.instance.ShowPopup(failedTimedPrefab);
+                        }
+                        else
+                        {
+                            MenuManager.instance.ShowPopup<FailedTimed>();
+                        }
                         break;
                 }
             }

--- a/Scripts/BrickBlast/RayBrickMediator.cs
+++ b/Scripts/BrickBlast/RayBrickMediator.cs
@@ -19,6 +19,9 @@ using System.Collections.Generic;
         public TextMeshProUGUI winCurrencyText;
         private bool winRewardGranted;
 
+        [SerializeField] private FailedTimed failedTimedPopup;
+        public FailedTimed FailedTimedPopup => failedTimedPopup;
+
         [SerializeField] private Sprite boosterAdSprite;
 
         // Reference to an external mediation component assigned in the inspector


### PR DESCRIPTION
## Summary
- Expose a serialized FailedTimed popup reference on RayBrickMediator for early access
- Use mediator-provided FailedTimed prefab in LevelManager, falling back to Resources if missing

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68aae06d9b94832d9c00f30301371121