### PR TITLE
Skip win screen for early levels in arcade mode

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -568,18 +568,25 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             GameDataManager.SetLevel(null);
 
             int subLevel = GameDataManager.GetSubLevelIndex();
+
             if (subLevel < 3)
             {
                 GameDataManager.SetSubLevelIndex(subLevel + 1);
+
+                // Move directly to the next level without showing the win screen
+                EventManager.GameStatus = EGameState.Playing;
+                GameManager.instance.OpenGame();
+                GameManager.instance.RestartLevel();
             }
             else
             {
                 int currentGroup = Mathf.CeilToInt(currentLevel / 3f);
                 GameDataManager.UnlockGroup(currentGroup + 1);
                 GameDataManager.ResetSubLevelIndex();
-            }
 
-            EventManager.GameStatus = EGameState.PreWin;
+                // Show end screen at the end of the stage
+                EventManager.GameStatus = EGameState.PreWin;
+            }
         }
 
         private void SetLose()


### PR DESCRIPTION
## Summary
- Skip end-game popup when winning early sub-levels in a stage
- Only show end screen after completing the third sub-level

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ab0965d06c832d9a612824c403082c