### PR TITLE
Use UserData.Level as single player level source

### DIFF
--- a/Scripts/MyCode/Controllers/BackgroundController.cs
+++ b/Scripts/MyCode/Controllers/BackgroundController.cs
@@ -31,7 +31,7 @@ namespace Ray.Controllers
             var bgSpawnProp = _bgSpawnConfig.BgSpawnProp;
             var bgElementSpawnProp = _bgSpawnConfig.BgElementSpawnProp;
 
-            int bgCount = Mathf.CeilToInt(Database.UserData.Stats.ReachLevel / 10f);
+            int bgCount = Mathf.CeilToInt(Database.UserData.Level / 10f);
             for (int i = 0; i < bgCount; i++)
             {
                 int targetY = bgSpawnProp.FirstSpawnY + (bgSpawnProp.IncrementSpawnY * i);
@@ -39,7 +39,7 @@ namespace Ray.Controllers
                 SpawnBg(c, targetY);
             }
 
-            int bgElementCount = Mathf.CeilToInt(Database.UserData.Stats.ReachLevel / 5);
+            int bgElementCount = Mathf.CeilToInt(Database.UserData.Level / 5);
             for (int i = 0; i < bgElementCount; i++)
             {
                 int targetY = bgElementSpawnProp.FirstSpawnY + (bgElementSpawnProp.IncrementSpawnY * i);

--- a/Scripts/MyCode/Controllers/ItemController.cs
+++ b/Scripts/MyCode/Controllers/ItemController.cs
@@ -33,7 +33,7 @@ namespace Ray.Controllers
         {
             _rayDebug.Event("SpawnAllItemsAtOnce", c, this);
 
-            for (int y = _itemSpawnConfig.FirstSpawnY; y > -Database.UserData.Stats.ReachLevel; y -= _itemSpawnConfig.IncrementSpawnY)
+            for (int y = _itemSpawnConfig.FirstSpawnY; y > -Database.UserData.Level; y -= _itemSpawnConfig.IncrementSpawnY)
             {
                 SpawnItem(c, y);
             }

--- a/Scripts/MyCode/Controllers/UIController.cs
+++ b/Scripts/MyCode/Controllers/UIController.cs
@@ -180,7 +180,7 @@ namespace Ray.Controllers
 
             _view.PulseCurrency(_element.Menu.MenuCurrency, Database.UserData.Stats.TotalCurrency);
 
-            _view.SetText(_element.Menu.ReachLevel, Database.UserData.Stats.ReachLevel);
+            _view.SetText(_element.Menu.ReachLevel, Database.UserData.Level);
             _view.SetText(_element.Menu.SpaceLevel, Database.UserData.Stats.SpaceLevel);
 
             string costIcon = ResourceService.Instance.PanalizedUser() ? "<sprite=2>" : "<sprite=0>";

--- a/Scripts/MyCode/Database/Database.cs
+++ b/Scripts/MyCode/Database/Database.cs
@@ -230,7 +230,6 @@ namespace Ray.Services
                 {
                     Dictionary<string, object> defaultData = defaultSnapshot.ToDictionary();
                     int defaultLevel = defaultData.ContainsKey("Level") ? Convert.ToInt32(defaultData["Level"]) : 1;
-                    int defaultReachLevel = defaultData.ContainsKey("ReachLevel") ? Convert.ToInt32(defaultData["ReachLevel"]) : defaultLevel;
                     int defaultSpaceLevel = defaultData.ContainsKey("SpaceLevel") ? Convert.ToInt32(defaultData["SpaceLevel"]) : 0;
                     int defaultPower1 = defaultData.ContainsKey("Power_1") ? Convert.ToInt32(defaultData["Power_1"]) : 0;
                     int defaultPower2 = defaultData.ContainsKey("Power_2") ? Convert.ToInt32(defaultData["Power_2"]) : 0;
@@ -250,7 +249,6 @@ namespace Ray.Services
 
                         Stats = new UserData.StatsData
                         {
-                            ReachLevel = defaultReachLevel,
                             SpaceLevel = defaultSpaceLevel,
                             Power_1 = defaultPower1,
                             Power_2 = defaultPower2,
@@ -329,10 +327,10 @@ namespace Ray.Services
                 UserData = saveData; // Transfer modifications to client after cheat check
 
                 // Check and update Highest Reach Event
-                if (UserData.Stats.ReachLevel > serverUserData.Stats.ReachLevel)
+                if (UserData.Level > serverUserData.Level)
                 {
                     List<int> sortedReachEvents = GameSettings.Events.SortedReachEvents();
-                    int highestValidEvent = sortedReachEvents.Where(e => e <= UserData.Stats.ReachLevel).DefaultIfEmpty(0).Max();
+                    int highestValidEvent = sortedReachEvents.Where(e => e <= UserData.Level).DefaultIfEmpty(0).Max();
                     if (highestValidEvent > UserData.Stats.HighestReachEvent)
                     {
                         UserData.Stats.HighestReachEvent = highestValidEvent;

--- a/Scripts/MyCode/Database/UserData.cs
+++ b/Scripts/MyCode/Database/UserData.cs
@@ -42,7 +42,6 @@ public class UserData
             if (level != value)
             {
                 level = value;
-                Stats.ReachLevel = value;
                 LevelChanged?.Invoke(value);
             }
         }
@@ -82,7 +81,6 @@ public class UserData
     public class StatsData
     {
         [FirestoreProperty] public int TotalCurrency { get; set; } = 0;
-        [FirestoreProperty] public int ReachLevel { get; set; } = 1;
         [FirestoreProperty] public int SpaceLevel { get; set; } = 0;
         [FirestoreProperty] public int RvCount { get; set; } = 0;
         [FirestoreProperty] public int HighestReachEvent { get; set; } = 0;

--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -82,7 +82,7 @@ namespace Ray.Services
             var saveData = Database.UserData.Copy();
             saveData.Stats.TotalCurrency -= upgradeCost;
 
-            if (upgradeType == UpgradeType.Reach) saveData.Stats.ReachLevel += upgradeProp.LevelIncrement;
+            if (upgradeType == UpgradeType.Reach) saveData.Level += upgradeProp.LevelIncrement;
             else saveData.Stats.SpaceLevel += upgradeProp.LevelIncrement;
 
             await Database.Instance.Save(saveData);
@@ -93,7 +93,7 @@ namespace Ray.Services
         public int UpgradeCost(UpgradeType upgradeType)
         {
             var upgradeProp = upgradeType == UpgradeType.Reach ? _resourceEvaluationConfig.ReachUpgradeProperties : _resourceEvaluationConfig.SpaceUpgradeProperties;
-            int level = upgradeType == UpgradeType.Reach ? Database.UserData.Stats.ReachLevel : Database.UserData.Stats.SpaceLevel;
+            int level = upgradeType == UpgradeType.Reach ? Database.UserData.Level : Database.UserData.Stats.SpaceLevel;
             var multiplierDic = upgradeType == UpgradeType.Reach ? Database.GameSettings.Multipliers.Reach : Database.GameSettings.Multipliers.Space;
 
             // Sort multipliers by level breakpoint (ascending order)

--- a/Scripts/MyCode/Services/TenjinService.cs
+++ b/Scripts/MyCode/Services/TenjinService.cs
@@ -169,7 +169,7 @@ namespace Ray.Services
         {
             // Cheat Events
             SendCheatEvent("HighestReachEvent", "-1", "-1");
-            SendCheatEvent("ReachLevel", "-1", "-1");
+            SendCheatEvent("Level", "-1", "-1");
             SendCheatEvent("RvCount", "-1", "-1");
             SendCheatEvent("SpaceLevel", "-1", "-1");
             SendCheatEvent("TotalCurrency", "-1", "-1");


### PR DESCRIPTION
## Summary
- remove redundant ReachLevel from user stats
- use `UserData.Level` for background, item spawn and UI
- update resource, analytics and database logic to work with `UserData.Level`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68ab15db00f0832dafd91ab20fac761d