### PR TITLE
Use UserData.Level as single player level source

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.State.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.State.cs
@@ -13,6 +13,7 @@
 using BlockPuzzleGameToolkit.Scripts.Enums;
 using BlockPuzzleGameToolkit.Scripts.System;
 using BlockPuzzleGameToolkit.Scripts.Popups;
+using Ray.Services;
 
 namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 {
@@ -68,7 +69,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                 int groupIndex = (currentLevel - 1) / 3;
                 int newLevel = groupIndex * 3 + 1;
                 currentLevel = newLevel;
-                GameDataManager.SetLevelNum(newLevel);
+                Database.UserData.SetLevel(newLevel);
                 GameDataManager.ResetSubLevelIndex();
                 GameDataManager.SetLevel(null);
                 GameManager.instance.RestartLevel();

--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -306,14 +306,13 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             else
             {
                 gameMode = GameDataManager.GetGameMode();
+                currentLevel = Database.UserData.Level;
                 if (gameMode == EGameMode.Classic)
                 {
                     _levelData = Resources.Load<Level>("Misc/ClassicLevel");
-                    currentLevel = Database.UserData.Level;
                 }
                 else
                 {
-                    currentLevel = GameDataManager.GetLevelNum();
                     _levelData = GameDataManager.GetLevel();
                 }
             }
@@ -564,7 +563,6 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 
             int nextLevel = Database.UserData.Level + 1;
             Database.UserData.SetLevel(nextLevel);
-            GameDataManager.LevelNum = nextLevel;
             GameDataManager.SetLevel(null);
 
             int subLevel = GameDataManager.GetSubLevelIndex();
@@ -631,7 +629,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             cellDeck.UpdateCellDeckAfterFail();
 
             currentLevel = failedLevel;
-            GameDataManager.SetLevelNum(failedLevel);
+            Database.UserData.SetLevel(failedLevel);
             GameDataManager.SetSubLevelIndex(failedSubLevelIndex);
 
             EventManager.GameStatus = EGameState.Playing;

--- a/Scripts/BrickBlast/Popups/MainMenu.cs
+++ b/Scripts/BrickBlast/Popups/MainMenu.cs
@@ -47,7 +47,6 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
             settingsButton.onClick.AddListener(SettingsButtonClicked);
           //  luckySpin.onClick.AddListener(LuckySpinButtonClicked);
             UpdateFreeSpinMarker();
-            GameDataManager.LevelNum = Ray.Services.Database.UserData.Level;
             var levelsCount = Resources.LoadAll<Level>("Levels").Length;
           //  luckySpin.gameObject.SetActive(GameManager.instance.GameSettings.enableLuckySpin);
             if(!GameManager.instance.GameSettings.enableTimedMode)

--- a/Scripts/BrickBlast/System/GameDataManager.cs
+++ b/Scripts/BrickBlast/System/GameDataManager.cs
@@ -22,8 +22,6 @@ namespace BlockPuzzleGameToolkit.Scripts.System
 {
     public static class GameDataManager
     {
-        public static int LevelNum;
-
         private static Level _level;
 
         public static bool isTestPlay = false;
@@ -49,7 +47,6 @@ namespace BlockPuzzleGameToolkit.Scripts.System
         public static void ClearPlayerProgress()
         {
             Database.UserData.SetLevel(1);
-            Database.UserData.SetGroupIndex(1);
         }
 
         public static void ClearALlData()
@@ -67,7 +64,6 @@ namespace BlockPuzzleGameToolkit.Scripts.System
             PlayerPrefs.DeleteAll();
             PlayerPrefs.Save();
             Database.UserData.SetLevel(1);
-            Database.UserData.SetGroupIndex(1);
             #endif
         }
 
@@ -76,7 +72,6 @@ namespace BlockPuzzleGameToolkit.Scripts.System
             int savedLevel = Database.UserData.Level;
             if (savedLevel < currentLevel)
             {
-                LevelNum = currentLevel;
                 Database.UserData.SetLevel(currentLevel);
             }
         }
@@ -92,13 +87,7 @@ namespace BlockPuzzleGameToolkit.Scripts.System
 
         public static int GetLevelNum()
         {
-            var level = Database.UserData.Level;
-            if (GetGameMode() == EGameMode.Adventure)
-            {
-                var groupIndex = Database.UserData.GroupIndex;
-                level += (groupIndex - 1) * 3;
-            }
-            return level;
+            return Database.UserData.Level;
         }
 
         public static int GetGroupIndex()
@@ -171,12 +160,6 @@ namespace BlockPuzzleGameToolkit.Scripts.System
             int currentLevel = GetLevelNum();
             int totalLevels = Resources.LoadAll<Level>("Levels").Length;
             return currentLevel < totalLevels;
-        }
-
-        public static void SetLevelNum(int stateCurrentLevel)
-        {
-            LevelNum = stateCurrentLevel;
-            Database.UserData.SetLevel(stateCurrentLevel);
         }
     }
 }

--- a/Scripts/BrickBlast/System/GameManager.cs
+++ b/Scripts/BrickBlast/System/GameManager.cs
@@ -207,9 +207,9 @@ namespace BlockPuzzleGameToolkit.Scripts.System
 
         public void NextLevel()
         {
-            GameDataManager.LevelNum++;
-            Database.UserData.SetLevel(GameDataManager.LevelNum);
-            GameDataManager.UnlockGroup(Mathf.CeilToInt(GameDataManager.LevelNum / 3f));
+            int nextLevel = Database.UserData.Level + 1;
+            Database.UserData.SetLevel(nextLevel);
+            GameDataManager.UnlockGroup(Mathf.CeilToInt(nextLevel / 3f));
             OpenGame();
             RestartLevel();
         }

--- a/Scripts/MyCode/Controllers/BackgroundController.cs
+++ b/Scripts/MyCode/Controllers/BackgroundController.cs
@@ -31,7 +31,7 @@ namespace Ray.Controllers
             var bgSpawnProp = _bgSpawnConfig.BgSpawnProp;
             var bgElementSpawnProp = _bgSpawnConfig.BgElementSpawnProp;
 
-            int bgCount = Mathf.CeilToInt(Database.UserData.Stats.ReachLevel / 10f);
+            int bgCount = Mathf.CeilToInt(Database.UserData.Level / 10f);
             for (int i = 0; i < bgCount; i++)
             {
                 int targetY = bgSpawnProp.FirstSpawnY + (bgSpawnProp.IncrementSpawnY * i);
@@ -39,7 +39,7 @@ namespace Ray.Controllers
                 SpawnBg(c, targetY);
             }
 
-            int bgElementCount = Mathf.CeilToInt(Database.UserData.Stats.ReachLevel / 5);
+            int bgElementCount = Mathf.CeilToInt(Database.UserData.Level / 5);
             for (int i = 0; i < bgElementCount; i++)
             {
                 int targetY = bgElementSpawnProp.FirstSpawnY + (bgElementSpawnProp.IncrementSpawnY * i);

--- a/Scripts/MyCode/Controllers/ItemController.cs
+++ b/Scripts/MyCode/Controllers/ItemController.cs
@@ -33,7 +33,7 @@ namespace Ray.Controllers
         {
             _rayDebug.Event("SpawnAllItemsAtOnce", c, this);
 
-            for (int y = _itemSpawnConfig.FirstSpawnY; y > -Database.UserData.Stats.ReachLevel; y -= _itemSpawnConfig.IncrementSpawnY)
+            for (int y = _itemSpawnConfig.FirstSpawnY; y > -Database.UserData.Level; y -= _itemSpawnConfig.IncrementSpawnY)
             {
                 SpawnItem(c, y);
             }

--- a/Scripts/MyCode/Controllers/UIController.cs
+++ b/Scripts/MyCode/Controllers/UIController.cs
@@ -180,7 +180,7 @@ namespace Ray.Controllers
 
             _view.PulseCurrency(_element.Menu.MenuCurrency, Database.UserData.Stats.TotalCurrency);
 
-            _view.SetText(_element.Menu.ReachLevel, Database.UserData.Stats.ReachLevel);
+            _view.SetText(_element.Menu.ReachLevel, Database.UserData.Level);
             _view.SetText(_element.Menu.SpaceLevel, Database.UserData.Stats.SpaceLevel);
 
             string costIcon = ResourceService.Instance.PanalizedUser() ? "<sprite=2>" : "<sprite=0>";

--- a/Scripts/MyCode/Database/Database.cs
+++ b/Scripts/MyCode/Database/Database.cs
@@ -230,7 +230,6 @@ namespace Ray.Services
                 {
                     Dictionary<string, object> defaultData = defaultSnapshot.ToDictionary();
                     int defaultLevel = defaultData.ContainsKey("Level") ? Convert.ToInt32(defaultData["Level"]) : 1;
-                    int defaultReachLevel = defaultData.ContainsKey("ReachLevel") ? Convert.ToInt32(defaultData["ReachLevel"]) : defaultLevel;
                     int defaultSpaceLevel = defaultData.ContainsKey("SpaceLevel") ? Convert.ToInt32(defaultData["SpaceLevel"]) : 0;
                     int defaultPower1 = defaultData.ContainsKey("Power_1") ? Convert.ToInt32(defaultData["Power_1"]) : 0;
                     int defaultPower2 = defaultData.ContainsKey("Power_2") ? Convert.ToInt32(defaultData["Power_2"]) : 0;
@@ -250,7 +249,6 @@ namespace Ray.Services
 
                         Stats = new UserData.StatsData
                         {
-                            ReachLevel = defaultReachLevel,
                             SpaceLevel = defaultSpaceLevel,
                             Power_1 = defaultPower1,
                             Power_2 = defaultPower2,
@@ -329,10 +327,10 @@ namespace Ray.Services
                 UserData = saveData; // Transfer modifications to client after cheat check
 
                 // Check and update Highest Reach Event
-                if (UserData.Stats.ReachLevel > serverUserData.Stats.ReachLevel)
+                if (UserData.Level > serverUserData.Level)
                 {
                     List<int> sortedReachEvents = GameSettings.Events.SortedReachEvents();
-                    int highestValidEvent = sortedReachEvents.Where(e => e <= UserData.Stats.ReachLevel).DefaultIfEmpty(0).Max();
+                    int highestValidEvent = sortedReachEvents.Where(e => e <= UserData.Level).DefaultIfEmpty(0).Max();
                     if (highestValidEvent > UserData.Stats.HighestReachEvent)
                     {
                         UserData.Stats.HighestReachEvent = highestValidEvent;

--- a/Scripts/MyCode/Database/UserData.cs
+++ b/Scripts/MyCode/Database/UserData.cs
@@ -42,7 +42,6 @@ public class UserData
             if (level != value)
             {
                 level = value;
-                Stats.ReachLevel = value;
                 LevelChanged?.Invoke(value);
             }
         }
@@ -82,7 +81,6 @@ public class UserData
     public class StatsData
     {
         [FirestoreProperty] public int TotalCurrency { get; set; } = 0;
-        [FirestoreProperty] public int ReachLevel { get; set; } = 1;
         [FirestoreProperty] public int SpaceLevel { get; set; } = 0;
         [FirestoreProperty] public int RvCount { get; set; } = 0;
         [FirestoreProperty] public int HighestReachEvent { get; set; } = 0;
@@ -156,19 +154,7 @@ public class UserData
     public void SetLevel(int value)
     {
         Level = value;
-
-        // Each group consists of three sub-levels (1-3). Only after the
-        // third sub-level is completed and the level would advance past
-        // 3 do we reset the sub-level counter and move to the next group.
-        // Previously the check used ">= 3" which caused the group index
-        // to advance prematurely when starting the third level. Using
-        // "> 3" ensures the group changes only after finishing the third
-        // level.
-        if (Level > 3)
-        {
-            Level = 1;
-            GroupIndex = GroupIndex + 1;
-        }
+        GroupIndex = ((value - 1) / 3) + 1;
 
         var saveData = Database.UserData.Copy();
         Database.Instance?.Save(saveData);

--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -82,7 +82,7 @@ namespace Ray.Services
             var saveData = Database.UserData.Copy();
             saveData.Stats.TotalCurrency -= upgradeCost;
 
-            if (upgradeType == UpgradeType.Reach) saveData.Stats.ReachLevel += upgradeProp.LevelIncrement;
+            if (upgradeType == UpgradeType.Reach) saveData.Level += upgradeProp.LevelIncrement;
             else saveData.Stats.SpaceLevel += upgradeProp.LevelIncrement;
 
             await Database.Instance.Save(saveData);
@@ -93,7 +93,7 @@ namespace Ray.Services
         public int UpgradeCost(UpgradeType upgradeType)
         {
             var upgradeProp = upgradeType == UpgradeType.Reach ? _resourceEvaluationConfig.ReachUpgradeProperties : _resourceEvaluationConfig.SpaceUpgradeProperties;
-            int level = upgradeType == UpgradeType.Reach ? Database.UserData.Stats.ReachLevel : Database.UserData.Stats.SpaceLevel;
+            int level = upgradeType == UpgradeType.Reach ? Database.UserData.Level : Database.UserData.Stats.SpaceLevel;
             var multiplierDic = upgradeType == UpgradeType.Reach ? Database.GameSettings.Multipliers.Reach : Database.GameSettings.Multipliers.Space;
 
             // Sort multipliers by level breakpoint (ascending order)

--- a/Scripts/MyCode/Services/TenjinService.cs
+++ b/Scripts/MyCode/Services/TenjinService.cs
@@ -169,7 +169,7 @@ namespace Ray.Services
         {
             // Cheat Events
             SendCheatEvent("HighestReachEvent", "-1", "-1");
-            SendCheatEvent("ReachLevel", "-1", "-1");
+            SendCheatEvent("Level", "-1", "-1");
             SendCheatEvent("RvCount", "-1", "-1");
             SendCheatEvent("SpaceLevel", "-1", "-1");
             SendCheatEvent("TotalCurrency", "-1", "-1");


### PR DESCRIPTION
## Summary
- derive group index from global `UserData.Level` so level no longer resets per group
- return `UserData.Level` directly from `GameDataManager.GetLevelNum`
- load levels in `LevelManager` based on global level across modes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(repositories not signed)*
- `apt-get install -y dotnet-sdk-7.0` *(unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_68ab15db00f0832dafd91ab20fac761d