### PR TITLE
Fix duplicate level increments and reset level when advancing groups

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.State.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.State.cs
@@ -66,10 +66,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             int subLevelIndex = GameDataManager.GetSubLevelIndex();
             if (subLevelIndex > 1)
             {
-                int groupIndex = (currentLevel - 1) / 3;
-                int newLevel = groupIndex * 3 + 1;
-                currentLevel = newLevel;
-                Database.UserData.SetLevel(newLevel);
+                currentLevel = 1;
+                Database.UserData.SetLevel(1);
                 GameDataManager.ResetSubLevelIndex();
                 GameDataManager.SetLevel(null);
                 GameManager.instance.RestartLevel();

--- a/Scripts/BrickBlast/System/GameManager.cs
+++ b/Scripts/BrickBlast/System/GameManager.cs
@@ -207,9 +207,6 @@ namespace BlockPuzzleGameToolkit.Scripts.System
 
         public void NextLevel()
         {
-            int nextLevel = Database.UserData.Level + 1;
-            Database.UserData.SetLevel(nextLevel);
-            GameDataManager.UnlockGroup(Mathf.CeilToInt(nextLevel / 3f));
             OpenGame();
             RestartLevel();
         }

--- a/Scripts/MyCode/Database/UserData.cs
+++ b/Scripts/MyCode/Database/UserData.cs
@@ -153,8 +153,15 @@ public class UserData
 
     public void SetLevel(int value)
     {
-        Level = value;
-        GroupIndex = ((value - 1) / 3) + 1;
+        if (value > 3)
+        {
+            GroupIndex = ((value - 1) / 3) + 1;
+            Level = ((value - 1) % 3) + 1;
+        }
+        else
+        {
+            Level = value;
+        }
 
         var saveData = Database.UserData.Copy();
         Database.Instance?.Save(saveData);


### PR DESCRIPTION
## Summary
- Prevent `NextLevel` from modifying user level and group
- Normalize `UserData.SetLevel` so advancing past level 3 bumps group and wraps to level 1
- Reset level to 1 on stage failure beyond sublevel one

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ac1b172434832d9648f4f4adc0fb0a