### PR TITLE
Reset level after arcade mode failure

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -594,9 +594,18 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
         private void SetLose()
         {
             if (gameMode == EGameMode.Classic)
+            {
                 GameState.Delete(EGameMode.Classic);
+                // Arcade modes shouldn't carry level progression. When the player
+                // fails, reset their level so the next run starts from level 1.
+                GameDataManager.SetLevelNum(1);
+            }
             else if (gameMode == EGameMode.Timed)
+            {
                 GameState.Delete(EGameMode.Timed);
+                // Timed mode behaves like an arcade run; ensure level resets on fail.
+                GameDataManager.SetLevelNum(1);
+            }
             OnLose?.Invoke();
             EventManager.GameStatus = EGameState.PreFailed;
         }


### PR DESCRIPTION
## Summary
- Reset player level to 1 when failing in Classic or Timed (arcade) modes to ensure runs restart from the first level

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac1d9a116c832da8fbdef32f51eda2