### PR TITLE
Reset level to 1 after arcade failure

### DIFF
--- a/Scripts/BrickBlast/Gameplay/BaseModeHandler.cs
+++ b/Scripts/BrickBlast/Gameplay/BaseModeHandler.cs
@@ -116,6 +116,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             ResourceService.Instance?.SubmitLevelScore(score);
             EventService.Player.OnParked?.Invoke(this);
             DeleteGameState();
+            Database.UserData.SetLevel(1);
         }
 
         private void HandleEndCurrencyChanged(Component c)


### PR DESCRIPTION
## Summary
- Reset player level to 1 when a score-based mode is lost

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac1e7c7dc8832da7d3ae0ace56ec0e