### PR TITLE
Refactor level tracking into stats

### DIFF
--- a/Scripts/BrickBlast/Gameplay/ClassicModeHandler.cs
+++ b/Scripts/BrickBlast/Gameplay/ClassicModeHandler.cs
@@ -59,7 +59,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             if (score > bestScore)
             {
                 ResourceManager.instance.GetResource("Score").Set(score);
-                int userLevel = Database.UserData.Level;
+                int userLevel = Database.UserData.Stats.Level;
                 //LeaderboardService.Instance.UpdateClassicLeaderboard(score, userLevel);
             }
 

--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -306,7 +306,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             else
             {
                 gameMode = GameDataManager.GetGameMode();
-                currentLevel = Database.UserData.Level;
+                currentLevel = Database.UserData.Stats.Level;
                 if (gameMode == EGameMode.Classic)
                 {
                     _levelData = Resources.Load<Level>("Misc/ClassicLevel");
@@ -561,7 +561,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 
             EventService.Player.OnParked?.Invoke(this);
 
-            int nextLevel = Database.UserData.Level + 1;
+            int nextLevel = Database.UserData.Stats.Level + 1;
             Database.UserData.SetLevel(nextLevel);
             GameDataManager.SetLevel(null);
 

--- a/Scripts/BrickBlast/System/GameDataManager.cs
+++ b/Scripts/BrickBlast/System/GameDataManager.cs
@@ -69,7 +69,7 @@ namespace BlockPuzzleGameToolkit.Scripts.System
 
         public static void UnlockLevel(int currentLevel)
         {
-            int savedLevel = Database.UserData.Level;
+            int savedLevel = Database.UserData.Stats.Level;
             if (savedLevel < currentLevel)
             {
                 Database.UserData.SetLevel(currentLevel);
@@ -78,7 +78,7 @@ namespace BlockPuzzleGameToolkit.Scripts.System
 
         public static void UnlockGroup(int groupIndex)
         {
-            int savedGroup = Database.UserData.GroupIndex;
+            int savedGroup = Database.UserData.Stats.GroupIndex;
             if (savedGroup < groupIndex)
             {
                 Database.UserData.SetGroupIndex(groupIndex);
@@ -87,12 +87,12 @@ namespace BlockPuzzleGameToolkit.Scripts.System
 
         public static int GetLevelNum()
         {
-            return Database.UserData.Level;
+            return Database.UserData.Stats.Level;
         }
 
         public static int GetGroupIndex()
         {
-            return Database.UserData.GroupIndex;
+            return Database.UserData.Stats.GroupIndex;
         }
 
         public static Level GetLevel()

--- a/Scripts/MyCode/Controllers/BackgroundController.cs
+++ b/Scripts/MyCode/Controllers/BackgroundController.cs
@@ -31,7 +31,7 @@ namespace Ray.Controllers
             var bgSpawnProp = _bgSpawnConfig.BgSpawnProp;
             var bgElementSpawnProp = _bgSpawnConfig.BgElementSpawnProp;
 
-            int bgCount = Mathf.CeilToInt(Database.UserData.Level / 10f);
+            int bgCount = Mathf.CeilToInt(Database.UserData.Stats.Level / 10f);
             for (int i = 0; i < bgCount; i++)
             {
                 int targetY = bgSpawnProp.FirstSpawnY + (bgSpawnProp.IncrementSpawnY * i);
@@ -39,7 +39,7 @@ namespace Ray.Controllers
                 SpawnBg(c, targetY);
             }
 
-            int bgElementCount = Mathf.CeilToInt(Database.UserData.Level / 5);
+            int bgElementCount = Mathf.CeilToInt(Database.UserData.Stats.Level / 5);
             for (int i = 0; i < bgElementCount; i++)
             {
                 int targetY = bgElementSpawnProp.FirstSpawnY + (bgElementSpawnProp.IncrementSpawnY * i);

--- a/Scripts/MyCode/Controllers/ItemController.cs
+++ b/Scripts/MyCode/Controllers/ItemController.cs
@@ -33,7 +33,7 @@ namespace Ray.Controllers
         {
             _rayDebug.Event("SpawnAllItemsAtOnce", c, this);
 
-            for (int y = _itemSpawnConfig.FirstSpawnY; y > -Database.UserData.Level; y -= _itemSpawnConfig.IncrementSpawnY)
+            for (int y = _itemSpawnConfig.FirstSpawnY; y > -Database.UserData.Stats.Level; y -= _itemSpawnConfig.IncrementSpawnY)
             {
                 SpawnItem(c, y);
             }

--- a/Scripts/MyCode/Controllers/UIController.cs
+++ b/Scripts/MyCode/Controllers/UIController.cs
@@ -180,8 +180,8 @@ namespace Ray.Controllers
 
             _view.PulseCurrency(_element.Menu.MenuCurrency, Database.UserData.Stats.TotalCurrency);
 
-            _view.SetText(_element.Menu.ReachLevel, Database.UserData.Level);
-            _view.SetText(_element.Menu.SpaceLevel, Database.UserData.Stats.SpaceLevel);
+            _view.SetText(_element.Menu.ReachLevel, Database.UserData.Stats.Level);
+            _view.SetText(_element.Menu.SpaceLevel, Database.UserData.Stats.Level);
 
             string costIcon = ResourceService.Instance.PanalizedUser() ? "<sprite=2>" : "<sprite=0>";
 

--- a/Scripts/MyCode/Database/Database.cs
+++ b/Scripts/MyCode/Database/Database.cs
@@ -186,7 +186,7 @@ namespace Ray.Services
 
             if (PlayerPrefs.HasKey("Level"))
             {
-                UserData.Level = PlayerPrefs.GetInt("Level");
+                UserData.Stats.Level = PlayerPrefs.GetInt("Level");
                 changed = true;
             }
 
@@ -230,7 +230,7 @@ namespace Ray.Services
                 {
                     Dictionary<string, object> defaultData = defaultSnapshot.ToDictionary();
                     int defaultLevel = defaultData.ContainsKey("Level") ? Convert.ToInt32(defaultData["Level"]) : 1;
-                    int defaultSpaceLevel = defaultData.ContainsKey("SpaceLevel") ? Convert.ToInt32(defaultData["SpaceLevel"]) : 0;
+                    int defaultGroupIndex = defaultData.ContainsKey("GroupIndex") ? Convert.ToInt32(defaultData["GroupIndex"]) : 1;
                     int defaultPower1 = defaultData.ContainsKey("Power_1") ? Convert.ToInt32(defaultData["Power_1"]) : 0;
                     int defaultPower2 = defaultData.ContainsKey("Power_2") ? Convert.ToInt32(defaultData["Power_2"]) : 0;
                     int defaultPower3 = defaultData.ContainsKey("Power_3") ? Convert.ToInt32(defaultData["Power_3"]) : 0;
@@ -249,14 +249,13 @@ namespace Ray.Services
 
                         Stats = new UserData.StatsData
                         {
-                            SpaceLevel = defaultSpaceLevel,
+                            Level = defaultLevel,
+                            GroupIndex = defaultGroupIndex,
                             Power_1 = defaultPower1,
                             Power_2 = defaultPower2,
                             Power_3 = defaultPower3,
                             Power_4 = defaultPower4
-                        },
-
-                        Level = defaultLevel
+                        }
                     };
 
                     // Save new user data to Firestore
@@ -327,10 +326,10 @@ namespace Ray.Services
                 UserData = saveData; // Transfer modifications to client after cheat check
 
                 // Check and update Highest Reach Event
-                if (UserData.Level > serverUserData.Level)
+                if (UserData.Stats.Level > serverUserData.Stats.Level)
                 {
                     List<int> sortedReachEvents = GameSettings.Events.SortedReachEvents();
-                    int highestValidEvent = sortedReachEvents.Where(e => e <= UserData.Level).DefaultIfEmpty(0).Max();
+                    int highestValidEvent = sortedReachEvents.Where(e => e <= UserData.Stats.Level).DefaultIfEmpty(0).Max();
                     if (highestValidEvent > UserData.Stats.HighestReachEvent)
                     {
                         UserData.Stats.HighestReachEvent = highestValidEvent;

--- a/Scripts/MyCode/Database/UserData.cs
+++ b/Scripts/MyCode/Database/UserData.cs
@@ -15,10 +15,6 @@ public class UserData
     [FirestoreProperty] public brdData bightdData { get; set; } = new brdData();
 
     public event Action<int> TotalCurrencyChanged;
-    public event Action<int> LevelChanged;
-    public event Action<int> GroupIndexChanged;
-    private int level = 1;
-    private int groupIndex = 1;
 
     public int TotalCurrency
     {
@@ -29,34 +25,6 @@ public class UserData
             {
                 Stats.TotalCurrency = value;
                 TotalCurrencyChanged?.Invoke(value);
-            }
-        }
-    }
-
-    [FirestoreProperty]
-    public int Level
-    {
-        get => level;
-        set
-        {
-            if (level != value)
-            {
-                level = value;
-                LevelChanged?.Invoke(value);
-            }
-        }
-    }
-
-    [FirestoreProperty]
-    public int GroupIndex
-    {
-        get => groupIndex;
-        set
-        {
-            if (groupIndex != value)
-            {
-                groupIndex = value;
-                GroupIndexChanged?.Invoke(value);
             }
         }
     }
@@ -81,7 +49,8 @@ public class UserData
     public class StatsData
     {
         [FirestoreProperty] public int TotalCurrency { get; set; } = 0;
-        [FirestoreProperty] public int SpaceLevel { get; set; } = 0;
+        [FirestoreProperty] public int Level { get; set; } = 1;
+        [FirestoreProperty] public int GroupIndex { get; set; } = 1;
         [FirestoreProperty] public int RvCount { get; set; } = 0;
         [FirestoreProperty] public int HighestReachEvent { get; set; } = 0;
         [FirestoreProperty] public int TotalSessions { get; set; } = 0;
@@ -155,12 +124,12 @@ public class UserData
     {
         if (value > 3)
         {
-            GroupIndex = ((value - 1) / 3) + 1;
-            Level = ((value - 1) % 3) + 1;
+            Stats.GroupIndex = ((value - 1) / 3) + 1;
+            Stats.Level = ((value - 1) % 3) + 1;
         }
         else
         {
-            Level = value;
+            Stats.Level = value;
         }
 
         var saveData = Database.UserData.Copy();
@@ -169,7 +138,7 @@ public class UserData
 
     public void SetGroupIndex(int value)
     {
-        GroupIndex = value;
+        Stats.GroupIndex = value;
         var saveData = Database.UserData.Copy();
         Database.Instance?.Save(saveData);
     }

--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -82,8 +82,7 @@ namespace Ray.Services
             var saveData = Database.UserData.Copy();
             saveData.Stats.TotalCurrency -= upgradeCost;
 
-            if (upgradeType == UpgradeType.Reach) saveData.Level += upgradeProp.LevelIncrement;
-            else saveData.Stats.SpaceLevel += upgradeProp.LevelIncrement;
+            saveData.Stats.Level += upgradeProp.LevelIncrement;
 
             await Database.Instance.Save(saveData);
 
@@ -93,7 +92,7 @@ namespace Ray.Services
         public int UpgradeCost(UpgradeType upgradeType)
         {
             var upgradeProp = upgradeType == UpgradeType.Reach ? _resourceEvaluationConfig.ReachUpgradeProperties : _resourceEvaluationConfig.SpaceUpgradeProperties;
-            int level = upgradeType == UpgradeType.Reach ? Database.UserData.Level : Database.UserData.Stats.SpaceLevel;
+            int level = Database.UserData.Stats.Level;
             var multiplierDic = upgradeType == UpgradeType.Reach ? Database.GameSettings.Multipliers.Reach : Database.GameSettings.Multipliers.Space;
 
             // Sort multipliers by level breakpoint (ascending order)
@@ -230,7 +229,7 @@ namespace Ray.Services
             LevelCurrency.Value = 0;
             LevelScore.Value = 0;
 
-            LevelSpace.Value = Database.UserData.Stats.SpaceLevel;
+            LevelSpace.Value = Database.UserData.Stats.Level;
 
             EventService.Resource.OnLevelResourceChanged.Invoke(this);
             EventService.Resource.OnEndCurrencyChanged.Invoke(this);

--- a/Scripts/MyCode/Services/TenjinService.cs
+++ b/Scripts/MyCode/Services/TenjinService.cs
@@ -171,7 +171,6 @@ namespace Ray.Services
             SendCheatEvent("HighestReachEvent", "-1", "-1");
             SendCheatEvent("Level", "-1", "-1");
             SendCheatEvent("RvCount", "-1", "-1");
-            SendCheatEvent("SpaceLevel", "-1", "-1");
             SendCheatEvent("TotalCurrency", "-1", "-1");
 
             // Send Hightest Reach Events


### PR DESCRIPTION
## Summary
- remove obsolete `SpaceLevel` from user stats
- track `Level` and `GroupIndex` inside `Stats`
- adjust services and UI to reference `Stats.Level`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68ac43d1995c832d8a391878d8ba5608