### PR TITLE
Fix shape generation null reference after revive

### DIFF
--- a/Scripts/BrickBlast/Gameplay/ItemFactory.cs
+++ b/Scripts/BrickBlast/Gameplay/ItemFactory.cs
@@ -52,18 +52,28 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 
         private ShapeTemplate GetNonRepeatedShapeTemplate(HashSet<ShapeTemplate> usedShapeTemplates)
         {
-            ShapeTemplate shapeTemplate = null;
             if (usedShapeTemplates == null)
             {
                 return GetRandomShape();
             }
 
+            ShapeTemplate shapeTemplate;
+            var attempts = 0;
             do
             {
                 shapeTemplate = GetRandomShape();
-            } while (usedShapeTemplates.Contains(shapeTemplate));
+                attempts++;
+                if (attempts > 100)
+                {
+                    break;
+                }
+            } while (shapeTemplate != null && usedShapeTemplates.Contains(shapeTemplate));
 
-            usedShapeTemplates.Add(shapeTemplate);
+            if (shapeTemplate != null)
+            {
+                usedShapeTemplates.Add(shapeTemplate);
+            }
+
             return shapeTemplate;
         }
 
@@ -74,7 +84,19 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                 ? shapes.Where(shape => shape.spawnFromLevel <= levelManager.currentLevel).ToArray()
                 : shapes.Where(shape => shape.scoreForSpawn <= GetClassicScore()).ToArray();
 
+            if (shapesToConsider.Length == 0)
+            {
+                shapesToConsider = shapes;
+            }
+
             var totalWeight = shapesToConsider.Sum(shape => shape.chanceForSpawn);
+            if (totalWeight <= 0)
+            {
+                return shapesToConsider.Length > 0
+                    ? shapesToConsider[Random.Range(0, shapesToConsider.Length)]
+                    : null;
+            }
+
             var randomWeight = Random.Range(0, totalWeight);
 
             foreach (var shape in shapesToConsider)

--- a/Scripts/BrickBlast/Gameplay/Shape.cs
+++ b/Scripts/BrickBlast/Gameplay/Shape.cs
@@ -78,6 +78,13 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
 
         public void UpdateShape(ShapeTemplate shapeTemplate)
         {
+            this.shapeTemplate = shapeTemplate;
+            if (shapeTemplate == null)
+            {
+                Debug.LogWarning("UpdateShape called with null template");
+                return;
+            }
+
             activeItems.Clear();
             for (var i = 0; i < row.Length; i++)
             {


### PR DESCRIPTION
## Summary
- prevent null shape generation by falling back to available templates and guarding against duplicates
- avoid NullReference by checking for null templates in `Shape.UpdateShape`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac4a49fd44832d8a32da229f80a4f6