### PR TITLE
Avoid flagging legitimate saves as cheating

### DIFF
--- a/Scripts/MyCode/Database/UserData.cs
+++ b/Scripts/MyCode/Database/UserData.cs
@@ -123,33 +123,38 @@ public class UserData
 
     public void SetLevel(int value)
     {
+        var saveData = Database.UserData.Copy();
+
         if (value > 3)
         {
-            Stats.GroupIndex = ((value - 1) / 3) + 1;
-            Stats.Level = ((value - 1) % 3) + 1;
+            saveData.Stats.GroupIndex = ((value - 1) / 3) + 1;
+            saveData.Stats.Level = ((value - 1) % 3) + 1;
         }
         else
         {
-            Stats.Level = value;
+            saveData.Stats.Level = value;
         }
-        int absoluteLevel = ((Stats.GroupIndex - 1) * 3) + Stats.Level;
-        if (absoluteLevel > Stats.HighestLevelReached)
+
+        int absoluteLevel = ((saveData.Stats.GroupIndex - 1) * 3) + saveData.Stats.Level;
+        if (absoluteLevel > saveData.Stats.HighestLevelReached)
         {
-            Stats.HighestLevelReached = absoluteLevel;
+            saveData.Stats.HighestLevelReached = absoluteLevel;
         }
-        var saveData = Database.UserData.Copy();
+
         Database.Instance?.Save(saveData);
     }
 
     public void SetGroupIndex(int value)
     {
-        Stats.GroupIndex = value;
-        int absoluteLevel = ((Stats.GroupIndex - 1) * 3) + Stats.Level;
-        if (absoluteLevel > Stats.HighestLevelReached)
-        {
-            Stats.HighestLevelReached = absoluteLevel;
-        }
         var saveData = Database.UserData.Copy();
+        saveData.Stats.GroupIndex = value;
+
+        int absoluteLevel = ((saveData.Stats.GroupIndex - 1) * 3) + saveData.Stats.Level;
+        if (absoluteLevel > saveData.Stats.HighestLevelReached)
+        {
+            saveData.Stats.HighestLevelReached = absoluteLevel;
+        }
+
         Database.Instance?.Save(saveData);
     }
 }

--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -167,44 +167,52 @@ namespace Ray.Services
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
         }
 
-        public void RewardBooster(BoosterType type)
+        public async void RewardBooster(BoosterType type)
         {
+            var saveData = Database.UserData.Copy();
+
             switch (type)
             {
                 case BoosterType.ClearRow:
-                    Database.UserData.Stats.Power_1 = Mathf.Clamp(Database.UserData.Stats.Power_1 + 1, 0, 99);
+                    saveData.Stats.Power_1 = Mathf.Clamp(saveData.Stats.Power_1 + 1, 0, 99);
                     break;
                 case BoosterType.ClearColumn:
-                    Database.UserData.Stats.Power_2 = Mathf.Clamp(Database.UserData.Stats.Power_2 + 1, 0, 99);
+                    saveData.Stats.Power_2 = Mathf.Clamp(saveData.Stats.Power_2 + 1, 0, 99);
                     break;
                 case BoosterType.ClearSquare:
-                    Database.UserData.Stats.Power_3 = Mathf.Clamp(Database.UserData.Stats.Power_3 + 1, 0, 99);
+                    saveData.Stats.Power_3 = Mathf.Clamp(saveData.Stats.Power_3 + 1, 0, 99);
                     break;
                 case BoosterType.ChangeShape:
-                    Database.UserData.Stats.Power_4 = Mathf.Clamp(Database.UserData.Stats.Power_4 + 1, 0, 99);
+                    saveData.Stats.Power_4 = Mathf.Clamp(saveData.Stats.Power_4 + 1, 0, 99);
                     break;
             }
+
+            await Database.Instance.Save(saveData);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
         }
 
-        public void ConsumeBooster(BoosterType type)
+        public async void ConsumeBooster(BoosterType type)
         {
+            var saveData = Database.UserData.Copy();
+
             switch (type)
             {
                 case BoosterType.ClearRow:
-                    Database.UserData.Stats.Power_1 = Mathf.Clamp(Database.UserData.Stats.Power_1 - 1, 0, 99);
+                    saveData.Stats.Power_1 = Mathf.Clamp(saveData.Stats.Power_1 - 1, 0, 99);
                     break;
                 case BoosterType.ClearColumn:
-                    Database.UserData.Stats.Power_2 = Mathf.Clamp(Database.UserData.Stats.Power_2 - 1, 0, 99);
+                    saveData.Stats.Power_2 = Mathf.Clamp(saveData.Stats.Power_2 - 1, 0, 99);
                     break;
                 case BoosterType.ClearSquare:
-                    Database.UserData.Stats.Power_3 = Mathf.Clamp(Database.UserData.Stats.Power_3 - 1, 0, 99);
+                    saveData.Stats.Power_3 = Mathf.Clamp(saveData.Stats.Power_3 - 1, 0, 99);
                     break;
                 case BoosterType.ChangeShape:
-                    Database.UserData.Stats.Power_4 = Mathf.Clamp(Database.UserData.Stats.Power_4 - 1, 0, 99);
+                    saveData.Stats.Power_4 = Mathf.Clamp(saveData.Stats.Power_4 - 1, 0, 99);
                     break;
             }
+
+            await Database.Instance.Save(saveData);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
         }


### PR DESCRIPTION
## Summary
- Update level and group setters to modify a copy of user data before saving
- Save booster rewards and consumption using copies to keep client state clean

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac51543294832d82c0714ce8a6add4