### PR TITLE
Fix Failed popup null reference and invalid level load

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -307,6 +307,15 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             {
                 gameMode = GameDataManager.GetGameMode();
                 currentLevel = Database.UserData.Stats.Level;
+
+                if (currentLevel <= 0)
+                {
+                    Debug.LogWarning($"Invalid level {currentLevel}. Resetting to level 1.");
+                    currentLevel = 1;
+                    Database.UserData.SetLevel(currentLevel);
+                    GameDataManager.SetLevel(null);
+                }
+
                 if (gameMode == EGameMode.Classic)
                 {
                     _levelData = Resources.Load<Level>("Misc/ClassicLevel");

--- a/Scripts/BrickBlast/Popups/Failed.cs
+++ b/Scripts/BrickBlast/Popups/Failed.cs
@@ -29,8 +29,15 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
 
         protected virtual void OnEnable()
         {
-            retryButton.onClick.AddListener(Retry);
-            closeButton.onClick.AddListener(CollectAndExit);
+            if (retryButton != null)
+            {
+                retryButton.onClick.AddListener(Retry);
+            }
+
+            if (closeButton != null)
+            {
+                closeButton.onClick.AddListener(CollectAndExit);
+            }
 
             if (currencyText != null)
             {
@@ -41,6 +48,24 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
             {
                 tripleRewardButton.onClick.AddListener(TripleReward);
                 tripleRewardButton.interactable = RewardedService.Instance.IsRewardedReady(RewardedType.Triple);
+            }
+        }
+
+        protected virtual void OnDisable()
+        {
+            if (retryButton != null)
+            {
+                retryButton.onClick.RemoveListener(Retry);
+            }
+
+            if (closeButton != null)
+            {
+                closeButton.onClick.RemoveListener(CollectAndExit);
+            }
+
+            if (tripleRewardButton != null)
+            {
+                tripleRewardButton.onClick.RemoveListener(TripleReward);
             }
         }
 


### PR DESCRIPTION
## Summary
- Avoid `NullReferenceException` in Failed popup by checking for missing UI components and cleaning up listeners
- Reset saved level to 1 when level data is missing to prevent restart errors

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ad7507ea5c832d8acb4120065b64ff