### PR TITLE
Show remaining booster uses

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/BoosterManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/BoosterManager.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 using BlockPuzzleGameToolkit.Scripts.LevelsData;
 using BlockPuzzleGameToolkit.Scripts.Enums;
 using BlockPuzzleGameToolkit.Scripts.System;
@@ -17,6 +18,11 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
         [SerializeField] private Button columnButton;
         [SerializeField] private Button squareButton;
         [SerializeField] private Button changeShapeButton;
+
+        [SerializeField] private TextMeshProUGUI rowUsesText;
+        [SerializeField] private TextMeshProUGUI columnUsesText;
+        [SerializeField] private TextMeshProUGUI squareUsesText;
+        [SerializeField] private TextMeshProUGUI changeShapeUsesText;
 
         private Cell lastHighlightedCell;
         private Camera mainCamera;
@@ -46,6 +52,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                 squareButton.onClick.AddListener(() => SelectBooster(BoosterType.ClearSquare));
             if (changeShapeButton != null)
                 changeShapeButton.onClick.AddListener(() => SelectBooster(BoosterType.ChangeShape));
+
+            UpdateBoosterTexts();
         }
 
         private void OnDestroy()
@@ -63,6 +71,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                     RewardedService.Instance.ShowRewarded(RewardedType.ExtraSpace, () =>
                     {
                         ResourceService.Instance?.RewardBooster(booster);
+                        UpdateBoosterTexts();
                         RayBrickMediator.Instance?.RefreshShop(this);
                     });
                 }
@@ -83,6 +92,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             {
                 ClearRandomSquare();
                 ResourceService.Instance?.ConsumeBooster(BoosterType.ClearSquare);
+                UpdateBoosterTexts();
                 return;
             }
 
@@ -106,6 +116,14 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             }
         }
 
+        private void UpdateBoosterTexts()
+        {
+            rowUsesText?.SetText(GetBoosterCount(BoosterType.ClearRow).ToString());
+            columnUsesText?.SetText(GetBoosterCount(BoosterType.ClearColumn).ToString());
+            squareUsesText?.SetText(GetBoosterCount(BoosterType.ClearSquare).ToString());
+            changeShapeUsesText?.SetText(GetBoosterCount(BoosterType.ChangeShape).ToString());
+        }
+
         private void ChangeShapes()
         {
             var deckManager = FindObjectOfType<CellDeckManager>();
@@ -114,6 +132,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                 deckManager.UpdateCellDeckAfterFail();
             }
             ResourceService.Instance?.ConsumeBooster(BoosterType.ChangeShape);
+            UpdateBoosterTexts();
             activeBooster = null;
         }
 
@@ -233,6 +252,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                             if (activeBooster.HasValue)
                             {
                                 ResourceService.Instance?.ConsumeBooster(activeBooster.Value);
+                                UpdateBoosterTexts();
                                 activeBooster = null;
                             }
                             lastHighlightedCell = null;

--- a/Scripts/BrickBlast/RayBrickMediator.cs
+++ b/Scripts/BrickBlast/RayBrickMediator.cs
@@ -6,6 +6,7 @@ using UnityEngine.UI;
 using BlockPuzzleGameToolkit.Scripts.Gameplay;
 using BlockPuzzleGameToolkit.Scripts.System;
 using BlockPuzzleGameToolkit.Scripts.Popups;
+using BlockPuzzleGameToolkit.Scripts.Enums;
 using System.Collections.Generic;
 
     public class RayBrickMediator : MonoBehaviour
@@ -38,11 +39,21 @@ using System.Collections.Generic;
         [SerializeField] GameObject LevelProgressCanvas;
 
         [SerializeField] private GameObject BoosterCanvas;
-        
-        
+
+
         private void Awake()
         {
             Instance = this;
+        }
+
+        private void OnEnable()
+        {
+            EventManager.OnGameStateChanged += HandleGameStateChange;
+        }
+
+        private void OnDisable()
+        {
+            EventManager.OnGameStateChanged -= HandleGameStateChange;
         }
 
         private void OnDestroy()
@@ -74,6 +85,8 @@ using System.Collections.Generic;
 
             if (Shop.Panel != null)
                 Shop.Panel.SetActive(false);
+
+            HandleGameStateChange(EventManager.GameStatus);
         }
 
         private void Update()
@@ -84,6 +97,11 @@ using System.Collections.Generic;
                 boosterRefreshTimer = 1f;
                 RefreshShop(this);
             }
+        }
+
+        private void HandleGameStateChange(EGameState state)
+        {
+            BoosterCanvas?.SetActive(state == EGameState.Playing);
         }
 
         public void SetReviveButton(Button button)


### PR DESCRIPTION
## Summary
- display each booster's remaining uses with TextMeshPro fields
- keep booster counts in sync after rewards or consumption
- toggle booster canvas visibility with game state changes

## Testing
- ⚠️ `dotnet test` (command not found: dotnet)
- ⚠️ `apt-get update` (403 Forbidden - package lists unavailable)
- ⚠️ `apt-get install -y dotnet-sdk-7.0` (package not found)
- ⚠️ `dotnet test` (command not found: dotnet)


------
https://chatgpt.com/codex/tasks/task_b_68aea6a29c60832d8aef282e2b2903d1