### PR TITLE
Avoid saving booster use after each activation

### DIFF
--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -192,27 +192,23 @@ namespace Ray.Services
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
         }
 
-        public async void ConsumeBooster(BoosterType type)
+        public void ConsumeBooster(BoosterType type)
         {
-            var saveData = Database.UserData.Copy();
-
             switch (type)
             {
                 case BoosterType.ClearRow:
-                    saveData.Stats.Power_1 = Mathf.Clamp(saveData.Stats.Power_1 - 1, 0, 99);
+                    Database.UserData.Stats.Power_1 = Mathf.Clamp(Database.UserData.Stats.Power_1 - 1, 0, 99);
                     break;
                 case BoosterType.ClearColumn:
-                    saveData.Stats.Power_2 = Mathf.Clamp(saveData.Stats.Power_2 - 1, 0, 99);
+                    Database.UserData.Stats.Power_2 = Mathf.Clamp(Database.UserData.Stats.Power_2 - 1, 0, 99);
                     break;
                 case BoosterType.ClearSquare:
-                    saveData.Stats.Power_3 = Mathf.Clamp(saveData.Stats.Power_3 - 1, 0, 99);
+                    Database.UserData.Stats.Power_3 = Mathf.Clamp(Database.UserData.Stats.Power_3 - 1, 0, 99);
                     break;
                 case BoosterType.ChangeShape:
-                    saveData.Stats.Power_4 = Mathf.Clamp(saveData.Stats.Power_4 - 1, 0, 99);
+                    Database.UserData.Stats.Power_4 = Mathf.Clamp(Database.UserData.Stats.Power_4 - 1, 0, 99);
                     break;
             }
-
-            await Database.Instance.Save(saveData);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
         }


### PR DESCRIPTION
## Summary
- Update `ResourceService.ConsumeBooster` to adjust in-memory booster counts without saving
- Trigger save only at round end so booster usage doesn't cause frequent database writes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68aebe08dad8832dabf17532302a78e4