### PR TITLE
Fix level progress display and star instantiation logic

### DIFF
--- a/Scripts/BrickBlast/RayBrickMediator.cs
+++ b/Scripts/BrickBlast/RayBrickMediator.cs
@@ -112,19 +112,14 @@ using System.Collections.Generic;
         {
 
             bool playing = state == EGameState.Playing;
+            bool inAdventure = GameDataManager.GetGameMode() == EGameMode.Adventure;
 
-            BoosterCanvas?.SetActive(playing);
-            LevelProgressCanvas?.SetActive(playing);
+            bool show = playing && inAdventure;
 
-            if (playing)
+            BoosterCanvas?.SetActive(show);
+            LevelProgressCanvas?.SetActive(show);
 
-            BoosterCanvas?.SetActive(state == EGameState.Playing);
-
-            bool showProgress = state == EGameState.Playing && GameDataManager.GetGameMode() == EGameMode.Classic;
-            LevelProgressCanvas?.SetActive(showProgress);
-
-            if (showProgress)
-
+            if (show)
             {
                 UpdateLevelProgress();
             }


### PR DESCRIPTION
## Summary
- ensure level progress canvas activates only during Adventure gameplay
- keep booster canvas disabled for Timed and Classic modes
- update stars under progress bar when level changes

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68aee8edae2c832d9d6ce226851e53d2