### PR TITLE
feat: add product metadata helpers for shop UI

### DIFF
--- a/Scripts/MyCode/Shop.cs
+++ b/Scripts/MyCode/Shop.cs
@@ -1,15 +1,53 @@
+using System.Reflection;
+using Ray.Services;
 using UnityEngine;
+using UnityEngine.Purchasing;
 
 public class Shop : MonoBehaviour
 {
-
-    [Header("Shop-Items")] [SerializeField]
-    public GameObject bundlePrefab;
-
+    [Header("Shop-Items")]
+    [SerializeField] public GameObject bundlePrefab;
     public GameObject itemPrefab;
     public GameObject SpecialPrefab;
+
+    private IStoreController StoreController
+    {
+        get
+        {
+            var field = typeof(IAPService).GetField("m_StoreController", BindingFlags.NonPublic | BindingFlags.Static);
+            return field?.GetValue(null) as IStoreController;
+        }
+    }
+
+    private Product GetProduct(string productId)
+    {
+        return StoreController?.products.WithID(productId);
+    }
+
+    public string GetLocalizedPrice(string productId)
+    {
+        var info = IAPService.Instance.ProductInfo(productId);
+        return info.localizedPrice;
+    }
+
+    public string GetProductName(string productId)
+    {
+        var info = IAPService.Instance.ProductInfo(productId);
+        return info.productName;
+    }
+
+    public string GetProductDescription(string productId)
+    {
+        var product = GetProduct(productId);
+        return product?.metadata.localizedDescription ?? string.Empty;
+    }
+
+    public ProductMetadata GetProductMetadata(string productId)
+    {
+        return GetProduct(productId)?.metadata;
+    }
+
     public void RefreshShopUI()
     {
-        
     }
 }


### PR DESCRIPTION
## Summary
- expose helper methods in Shop for retrieving localized product name, price and description
- use existing IAPService store data to look up product metadata

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b01ca3b710832da7d3d4ed10458df9