### PR TITLE
fix: wait for IAP data before building shop items

### DIFF
--- a/Scripts/MyCode/Shop.cs
+++ b/Scripts/MyCode/Shop.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.Threading.Tasks;
 using Ray.Services;
 using TMPro;
 using UnityEngine;
@@ -61,9 +62,16 @@ public class Shop : MonoBehaviour
         return GetProduct(productId)?.metadata;
     }
 
-    public void BuildBasicItems()
+    public async void BuildBasicItems()
     {
         Debug.Log("Shay : Bulding UI 1");
+
+        while (Database.GameSettings == null ||
+               Database.GameSettings.InAppPurchases == null ||
+               Database.GameSettings.InAppPurchases.Consumables == null)
+        {
+            await Task.Yield();
+        }
 
         foreach (var productId in Database.GameSettings.InAppPurchases.Consumables.Keys)
         {


### PR DESCRIPTION
## Summary
- prevent NullReferenceException by waiting for in-app purchase data before building shop items

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b039ad93f8832dab58111c9c630785