### PR TITLE
Add bundle_2 support to shop

### DIFF
--- a/Scripts/MyCode/Database/GameSettingsRay.cs
+++ b/Scripts/MyCode/Database/GameSettingsRay.cs
@@ -113,6 +113,7 @@ public class GameSettingsRay
         [FirestoreProperty] public Dictionary<string, int> Consumables { get; set; }
         [FirestoreProperty] public string SubscriptionNoAds { get; set; }
         [FirestoreProperty] public BundleData Bundle_1 { get; set; }
+        [FirestoreProperty] public BundleData Bundle_2 { get; set; }
 
         public int ConsumableRewardById(string productId)
         {

--- a/Scripts/MyCode/Services/IAPService.cs
+++ b/Scripts/MyCode/Services/IAPService.cs
@@ -103,7 +103,9 @@ namespace Ray.Services
 
             builder.AddProduct(Database.GameSettings.InAppPurchases.SubscriptionNoAds, ProductType.Subscription);
             builder.AddProduct(Database.GameSettings.InAppPurchases.Bundle_1.ID , ProductType.Consumable);
+            builder.AddProduct(Database.GameSettings.InAppPurchases.Bundle_2.ID , ProductType.Consumable);
             Debug.Log($"Shay : {Database.GameSettings.InAppPurchases.Bundle_1.ID}");
+            Debug.Log($"Shay : {Database.GameSettings.InAppPurchases.Bundle_2.ID}");
             UnityPurchasing.Initialize(this, builder);
 
             

--- a/Scripts/MyCode/Shop.cs
+++ b/Scripts/MyCode/Shop.cs
@@ -125,6 +125,13 @@ public class Shop : MonoBehaviour
         SetText(bundle_1, bundle.Booster_Square.ToString(), "2nd-offer-panel", "2ndOffer_2", "text-offer");
         SetText(bundle_1, bundle.Booster_Shape.ToString(), "2nd-offer-panel", "2ndOffer_3", "text-offer");
 
+        var bundle2 = Database.GameSettings.InAppPurchases.Bundle_2;
+        SetText(bundle_2, GetLocalizedPrice(bundle2.ID), "purchase-button", "text-price");
+        SetText(bundle_2, bundle2.Coins.ToString(), "mainOffer", "text-offer");
+        SetText(bundle_2, bundle2.Booster_Row.ToString(), "2nd-offer-panel", "2ndOffer", "text-offer");
+        SetText(bundle_2, bundle2.Booster_Col.ToString(), "2nd-offer-panel", "2ndOffer_1", "text-offer");
+        SetText(bundle_2, bundle2.Booster_Square.ToString(), "2nd-offer-panel", "2ndOffer_2", "text-offer");
+        SetText(bundle_2, bundle2.Booster_Shape.ToString(), "2nd-offer-panel", "2ndOffer_3", "text-offer");
     }
     
 }


### PR DESCRIPTION
## Summary
- extend in-app purchase configuration with bundle_2 data
- update IAP initialization to register bundle_2
- refresh shop UI with bundle_2 bundle details

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b05fb4f0a4832da9d7d10a30fe9b0b