### PR TITLE
Add booster rewards for IAP bundles

### DIFF
--- a/Scripts/MyCode/Database/GameSettingsRay.cs
+++ b/Scripts/MyCode/Database/GameSettingsRay.cs
@@ -111,6 +111,7 @@ public class GameSettingsRay
     public class InAppPurchasesData
     {
         [FirestoreProperty] public Dictionary<string, int> Consumables { get; set; }
+        [FirestoreProperty] public Dictionary<string, BundleReward> Bundles { get; set; }
         [FirestoreProperty] public string SubscriptionNoAds { get; set; }
 
         public int ConsumableRewardById(string productId)
@@ -121,6 +122,22 @@ public class GameSettingsRay
             }
             return 0;
         }
+
+        public BundleReward BundleRewardById(string productId)
+        {
+            if (Bundles != null && Bundles.TryGetValue(productId, out var reward))
+            {
+                return reward;
+            }
+            return null;
+        }
+    }
+
+    [FirestoreData]
+    public class BundleReward
+    {
+        [FirestoreProperty] public int Currency { get; set; }
+        [FirestoreProperty] public Dictionary<string, int> Boosters { get; set; }
     }
 
     [FirestoreData]

--- a/Scripts/MyCode/Services/IAPService.cs
+++ b/Scripts/MyCode/Services/IAPService.cs
@@ -287,6 +287,33 @@ namespace Ray.Services
             var saveData = Database.UserData.Copy();
             saveData.Stats.TotalCurrency += rewardAmount;
 
+            var bundleReward = Database.GameSettings.InAppPurchases.BundleRewardById(product.definition.id);
+            if (bundleReward != null && bundleReward.Boosters != null)
+            {
+                foreach (var booster in bundleReward.Boosters)
+                {
+                    if (Enum.TryParse(booster.Key, out BoosterType boosterType))
+                    {
+                        int amount = booster.Value;
+                        switch (boosterType)
+                        {
+                            case BoosterType.ClearRow:
+                                saveData.Stats.Power_1 = Mathf.Clamp(saveData.Stats.Power_1 + amount, 0, 99);
+                                break;
+                            case BoosterType.ClearColumn:
+                                saveData.Stats.Power_2 = Mathf.Clamp(saveData.Stats.Power_2 + amount, 0, 99);
+                                break;
+                            case BoosterType.ClearSquare:
+                                saveData.Stats.Power_3 = Mathf.Clamp(saveData.Stats.Power_3 + amount, 0, 99);
+                                break;
+                            case BoosterType.ChangeShape:
+                                saveData.Stats.Power_4 = Mathf.Clamp(saveData.Stats.Power_4 + amount, 0, 99);
+                                break;
+                        }
+                    }
+                }
+            }
+
             await Database.Instance.Save(saveData);
 
             EventService.IAP.OnPurchasedConsumable.Invoke(this);


### PR DESCRIPTION
## Summary
- track bundle rewards including boosters in `GameSettingsRay`
- grant boosters alongside coins when purchasing a bundle

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b3efbba120832d992aa0eb534d8681