### PR TITLE
Ensure Time.timeScale resets between play sessions

### DIFF
--- a/Scripts/BrickBlast/System/GameManager.cs
+++ b/Scripts/BrickBlast/System/GameManager.cs
@@ -40,6 +40,12 @@ namespace BlockPuzzleGameToolkit.Scripts.System
         public Action<bool, List<string>> OnPurchasesRestored;
         public ProductID noAdsProduct;
 
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void ResetTimeScale()
+        {
+            Time.timeScale = 1f;
+        }
+
         public int Score { get=> ResourceManager.instance.GetResource("Score").GetValue(); set => ResourceManager.instance.GetResource("Score").Set(value); }
 
         public override void Awake()
@@ -62,6 +68,7 @@ namespace BlockPuzzleGameToolkit.Scripts.System
         private void OnDisable()
         {
             GameDataManager.isTestPlay = false; // Reset isTestPlay
+            Time.timeScale = 1f; // Ensure time scale restored
         }
 
         private bool IsTutorialShown()


### PR DESCRIPTION
## Summary
- Reset Time.timeScale to 1 on startup and when exiting play mode

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b53a446a38832db7a37a96fbb23f59