### PR TITLE
Clean up editor callbacks to prevent lingering processes

### DIFF
--- a/Scripts/BrickBlast/Editor/Autorun.cs
+++ b/Scripts/BrickBlast/Editor/Autorun.cs
@@ -23,12 +23,19 @@ namespace BlockPuzzleGameToolkit.Scripts.Editor
     {
         static Autorun()
         {
-            EditorApplication.update += InitProject;
+            EditorApplication.delayCall += InitProject;
+            AssemblyReloadEvents.beforeAssemblyReload += OnBeforeAssemblyReload;
+        }
+
+        private static void OnBeforeAssemblyReload()
+        {
+            EditorApplication.delayCall -= InitProject;
+            AssemblyReloadEvents.beforeAssemblyReload -= OnBeforeAssemblyReload;
         }
 
         private static void InitProject()
         {
-            EditorApplication.update -= InitProject;
+            EditorApplication.delayCall -= InitProject;
             if (EditorApplication.timeSinceStartup < 10 || !EditorPrefs.GetBool(Application.dataPath + "AlreadyOpened"))
             {
                 if (SceneManager.GetActiveScene().name != "game" && Directory.Exists("Assets/BlockPuzzleGameToolkit/Scenes"))

--- a/Scripts/BrickBlast/GUI/Orientation/OrientationManager.cs
+++ b/Scripts/BrickBlast/GUI/Orientation/OrientationManager.cs
@@ -89,6 +89,11 @@ namespace BlockPuzzleGameToolkit.Scripts.GUI.Orientation
             EditorApplication.update -= EditorUpdate;
         }
 
+        private void OnDestroy()
+        {
+            EditorApplication.update -= EditorUpdate;
+        }
+
         private void EditorUpdate()
         {
             if (!detectInEditor || Application.isPlaying)

--- a/Scripts/BrickBlast/Utils/ImageCreator/Editor/ImageCreator.cs
+++ b/Scripts/BrickBlast/Utils/ImageCreator/Editor/ImageCreator.cs
@@ -22,6 +22,13 @@ namespace BlockPuzzleGameToolkit.Scripts.Utils.ImageCreator.Editor
         static ImageCreator()
         {
             EditorApplication.hierarchyChanged += OnChanged;
+            AssemblyReloadEvents.beforeAssemblyReload += OnBeforeAssemblyReload;
+        }
+
+        private static void OnBeforeAssemblyReload()
+        {
+            EditorApplication.hierarchyChanged -= OnChanged;
+            AssemblyReloadEvents.beforeAssemblyReload -= OnBeforeAssemblyReload;
         }
 
         private static void OnChanged()


### PR DESCRIPTION
## Summary
- Use `delayCall` and assembly reload cleanup in `Autorun` to avoid stray update hooks
- Unregister ImageCreator hierarchy change listener on assembly reload
- Ensure OrientationManager always removes its editor update callback

## Testing
- ⚠️ `dotnet build` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68b542743040832db762f7e259ba6360