### PR TITLE
Ensure DontDestroyOnLoad is only applied to root objects

### DIFF
--- a/Scripts/BrickBlast/Popups/MenuManager.cs
+++ b/Scripts/BrickBlast/Popups/MenuManager.cs
@@ -32,7 +32,11 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
         public override void Awake()
         {
             base.Awake();
-            DontDestroyOnLoad(this);
+            if (transform.parent != null)
+            {
+                transform.SetParent(null);
+            }
+            DontDestroyOnLoad(gameObject);
         }
 
         private void OnEnable()

--- a/Scripts/BrickBlast/System/GameManager.cs
+++ b/Scripts/BrickBlast/System/GameManager.cs
@@ -51,7 +51,11 @@ namespace BlockPuzzleGameToolkit.Scripts.System
         public override void Awake()
         {
             base.Awake();
-            DontDestroyOnLoad(this);
+            if (transform.parent != null)
+            {
+                transform.SetParent(null);
+            }
+            DontDestroyOnLoad(gameObject);
             Application.targetFrameRate = 60;
             DOTween.SetTweensCapacity(1250, 512);
         }

--- a/Scripts/MyCode/Controllers/SoundController.cs
+++ b/Scripts/MyCode/Controllers/SoundController.cs
@@ -34,6 +34,10 @@ namespace Ray.Controllers
             Instance = this;
 
             // Optional: Persist between scenes
+            if (transform.parent != null)
+            {
+                transform.SetParent(null);
+            }
             DontDestroyOnLoad(gameObject);
         }
 

--- a/Scripts/MyCode/Controllers/UIController.cs
+++ b/Scripts/MyCode/Controllers/UIController.cs
@@ -32,6 +32,10 @@ namespace Ray.Controllers
             }
 
             Instance = this;
+            if (transform.parent != null)
+            {
+                transform.SetParent(null);
+            }
             DontDestroyOnLoad(gameObject); // Optional: Keep UIController across scenes
         }
 

--- a/Scripts/MyCode/Events/EventService.cs
+++ b/Scripts/MyCode/Events/EventService.cs
@@ -7,6 +7,10 @@ namespace Ray.Services
     {
         private void Awake()
         {
+            if (transform.parent != null)
+            {
+                transform.SetParent(null);
+            }
             DontDestroyOnLoad(gameObject);
         }
 

--- a/Scripts/MyCode/Mediators/UIEventMediator.cs
+++ b/Scripts/MyCode/Mediators/UIEventMediator.cs
@@ -5,6 +5,10 @@ public class UIEventMediator : MonoBehaviour
 {
     private void Awake()
     {
+        if (transform.parent != null)
+        {
+            transform.SetParent(null);
+        }
         DontDestroyOnLoad(gameObject);
     }
 

--- a/Scripts/MyCode/Services/BufferService.cs
+++ b/Scripts/MyCode/Services/BufferService.cs
@@ -28,6 +28,10 @@ public class BufferService : MonoBehaviour
         }
 
         Instance = this;
+        if (transform.parent != null)
+        {
+            transform.SetParent(null);
+        }
         DontDestroyOnLoad(gameObject);
 
         SceneManager.sceneLoaded += OnSceneLoaded;


### PR DESCRIPTION
## Summary
- Unparent service and controller objects before calling `DontDestroyOnLoad`
- Apply same unparenting to managers to prevent runtime warnings

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b54c206534832da93ce08954339977