### PR TITLE
fix: prevent null reference in quit popup

### DIFF
--- a/Scripts/BrickBlast/Popups/Quit.cs
+++ b/Scripts/BrickBlast/Popups/Quit.cs
@@ -21,7 +21,35 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
 
         private void OnEnable()
         {
-            yes.onClick.AddListener(Application.Quit);
+            if (yes == null)
+            {
+                var buttons = GetComponentsInChildren<CustomButton>(true);
+                foreach (var button in buttons)
+                {
+                    if (button != closeButton)
+                    {
+                        yes = button;
+                        break;
+                    }
+                }
+            }
+
+            if (yes != null)
+            {
+                yes.onClick.AddListener(Application.Quit);
+            }
+            else
+            {
+                Debug.LogWarning("Yes button is missing in Quit popup.", this);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (yes != null)
+            {
+                yes.onClick.RemoveListener(Application.Quit);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- avoid null reference in Quit popup by detecting 'yes' button at runtime and guarding listener registration

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b551f09488832db3fb3b5fc2b93a81