### PR TITLE
Fix Settings exit button returning to main menu without quit prompt

### DIFF
--- a/Scripts/BrickBlast/Popups/Settings.cs
+++ b/Scripts/BrickBlast/Popups/Settings.cs
@@ -187,7 +187,11 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
             StopInteration();
 
             Close();
-            GameManager.instance.MainMenu();
+
+            if (StateManager.instance.CurrentState != EScreenStates.MainMenu)
+            {
+                GameManager.instance.MainMenu();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- avoid showing quit confirmation when closing Settings from main menu

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b553857a10832dbe912eecb8b5c5be