### PR TITLE
Save booster consumption to keep stats in sync

### DIFF
--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -195,23 +195,27 @@ namespace Ray.Services
             RayBrickMediator.Instance?.RefreshShop(this);
         }
 
-        public void ConsumeBooster(BoosterType type)
+        public async void ConsumeBooster(BoosterType type)
         {
+            var saveData = Database.UserData.Copy();
+
             switch (type)
             {
                 case BoosterType.ClearRow:
-                    Database.UserData.Stats.Power_1 = Mathf.Clamp(Database.UserData.Stats.Power_1 - 1, 0, 99);
+                    saveData.Stats.Power_1 = Mathf.Clamp(saveData.Stats.Power_1 - 1, 0, 99);
                     break;
                 case BoosterType.ClearColumn:
-                    Database.UserData.Stats.Power_2 = Mathf.Clamp(Database.UserData.Stats.Power_2 - 1, 0, 99);
+                    saveData.Stats.Power_2 = Mathf.Clamp(saveData.Stats.Power_2 - 1, 0, 99);
                     break;
                 case BoosterType.ClearSquare:
-                    Database.UserData.Stats.Power_3 = Mathf.Clamp(Database.UserData.Stats.Power_3 - 1, 0, 99);
+                    saveData.Stats.Power_3 = Mathf.Clamp(saveData.Stats.Power_3 - 1, 0, 99);
                     break;
                 case BoosterType.ChangeShape:
-                    Database.UserData.Stats.Power_4 = Mathf.Clamp(Database.UserData.Stats.Power_4 - 1, 0, 99);
+                    saveData.Stats.Power_4 = Mathf.Clamp(saveData.Stats.Power_4 - 1, 0, 99);
                     break;
             }
+
+            await Database.Instance.Save(saveData);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
             RayBrickMediator.Instance?.RefreshShop(this);


### PR DESCRIPTION
## Summary
- save booster usage back to the database so local stats stay aligned with the server

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_b_68b69cf6bcc0832db752d043d68a3e93