### PR TITLE
fix: prevent false level mismatch warnings

### DIFF
--- a/Scripts/MyCode/Database/Database.cs
+++ b/Scripts/MyCode/Database/Database.cs
@@ -291,6 +291,15 @@ namespace Ray.Services
 
                 foreach (PropertyInfo prop in typeof(UserData.StatsData).GetProperties())
                 {
+                    // Level and HighestLevelReached are updated locally before a save occurs,
+                    // which causes a false mismatch when compared against the server snapshot.
+                    // Skip these fields when performing the cheat/mismatch detection.
+                    if (prop.Name == nameof(UserData.StatsData.Level) ||
+                        prop.Name == nameof(UserData.StatsData.HighestLevelReached))
+                    {
+                        continue;
+                    }
+
                     if (prop.PropertyType == typeof(int)) // Ensure property is an int before casting
                     {
                         int clientValue = (int)prop.GetValue(UserData.Stats);


### PR DESCRIPTION
## Summary
- avoid logging mismatches for `Level` and `HighestLevelReached` which update locally before saving

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b6a0cb61c4832dbb2e2259e670da99