### PR TITLE
Ignore GroupIndex in stats mismatch detection

### DIFF
--- a/Scripts/MyCode/Database/Database.cs
+++ b/Scripts/MyCode/Database/Database.cs
@@ -291,10 +291,11 @@ namespace Ray.Services
 
                 foreach (PropertyInfo prop in typeof(UserData.StatsData).GetProperties())
                 {
-                    // Level and HighestLevelReached are updated locally before a save occurs,
+                    // Level, GroupIndex and HighestLevelReached are updated locally before a save occurs,
                     // which causes a false mismatch when compared against the server snapshot.
                     // Skip these fields when performing the cheat/mismatch detection.
                     if (prop.Name == nameof(UserData.StatsData.Level) ||
+                        prop.Name == nameof(UserData.StatsData.GroupIndex) ||
                         prop.Name == nameof(UserData.StatsData.HighestLevelReached))
                     {
                         continue;


### PR DESCRIPTION
## Summary
- avoid false cheat detection by excluding `GroupIndex` from stats mismatch checks

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_b_68b6a259fda0832dba310e684b9ddd82