### PR TITLE
Centralize game save operations

### DIFF
--- a/Scripts/BrickBlast/Data/ResourceObject.cs
+++ b/Scripts/BrickBlast/Data/ResourceObject.cs
@@ -75,7 +75,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Data
                 {
                     var saveData = Database.UserData.Copy();
                     saveData.TotalCurrency += amount;
-                    await Database.Instance.Save(saveData);
+                    await SaveService.Instance.Save(saveData);
                 }
             }
             else
@@ -95,7 +95,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Data
                 {
                     var saveData = Database.UserData.Copy();
                     saveData.TotalCurrency = amount;
-                    await Database.Instance.Save(saveData);
+                    await SaveService.Instance.Save(saveData);
                 }
             }
             else
@@ -118,7 +118,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Data
                     {
                         var saveData = Database.UserData.Copy();
                         saveData.TotalCurrency -= amount;
-                        _ = Database.Instance.Save(saveData);
+                        _ = SaveService.Instance.Save(saveData);
                     }
                 }
                 else

--- a/Scripts/MyCode/Database/Database.cs
+++ b/Scripts/MyCode/Database/Database.cs
@@ -432,7 +432,7 @@ namespace Ray.Services
             UserData.Stats.TotalCurrency++;
 
             var saveData = Database.UserData.Copy();
-            await Database.Instance.Save(saveData);
+            await SaveService.Instance.Save(saveData);
         }
 
         // Development

--- a/Scripts/MyCode/Database/UserData.cs
+++ b/Scripts/MyCode/Database/UserData.cs
@@ -130,7 +130,7 @@ public class UserData
     {
         var saveData = Database.UserData.Copy();
         saveData.TotalCurrency += amount;
-        await Database.Instance?.Save(saveData);
+        await SaveService.Instance.Save(saveData);
     }
 
     public async Task AddScoreAsCurrency(int score)
@@ -138,7 +138,7 @@ public class UserData
         var saveData = Database.UserData.Copy();
         saveData.Stats.TotalCurrency += score;
         saveData.Stats.TotalSessions++;
-        await Database.Instance?.Save(saveData);
+        await SaveService.Instance.Save(saveData);
     }
 
     public async Task<bool> SpendCurrency(int amount)
@@ -147,7 +147,7 @@ public class UserData
         {
             var saveData = Database.UserData.Copy();
             saveData.TotalCurrency -= amount;
-            await Database.Instance?.Save(saveData);
+            await SaveService.Instance.Save(saveData);
             return true;
         }
         return false;
@@ -161,7 +161,7 @@ public class UserData
         Level = value;
 
         var saveData = Database.UserData.Copy();
-        Database.Instance?.Save(saveData);
+        SaveService.Instance.Save(saveData);
     }
 
     public void SetGroupIndex(int value)
@@ -177,6 +177,6 @@ public class UserData
         }
 
         var saveData = Database.UserData.Copy();
-        Database.Instance?.Save(saveData);
+        SaveService.Instance.Save(saveData);
     }
 }

--- a/Scripts/MyCode/Services/IAPService.cs
+++ b/Scripts/MyCode/Services/IAPService.cs
@@ -314,7 +314,7 @@ namespace Ray.Services
                 }
             }
 
-            await Database.Instance.Save(saveData);
+            await SaveService.Instance.Save(saveData);
 
             EventService.IAP.OnPurchasedConsumable.Invoke(this);
 

--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -85,7 +85,7 @@ namespace Ray.Services
             if (upgradeType == UpgradeType.Reach) saveData.Stats.ReachLevel += upgradeProp.LevelIncrement;
             else saveData.Stats.SpaceLevel += upgradeProp.LevelIncrement;
 
-            await Database.Instance.Save(saveData);
+            await SaveService.Instance.Save(saveData);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
         }
@@ -164,7 +164,7 @@ namespace Ray.Services
 
             saveData.Stats.TotalCurrency -= cost;
 
-            await Database.Instance.Save(saveData);
+            await SaveService.Instance.Save(saveData);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
         }
@@ -189,7 +189,7 @@ namespace Ray.Services
                     break;
             }
 
-            await Database.Instance.Save(saveData);
+            await SaveService.Instance.Save(saveData);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
         }
@@ -214,7 +214,7 @@ namespace Ray.Services
                     break;
             }
 
-            await Database.Instance.Save(saveData);
+            await SaveService.Instance.Save(saveData);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
 
@@ -226,7 +226,7 @@ namespace Ray.Services
             _rayDebug.Event("RewardNoEnemies", c, this);
 
             var saveData = Database.UserData.Copy();
-            await Database.Instance.Save(saveData);
+            await SaveService.Instance.Save(saveData);
 
             NoEnemies.Value = true;
 
@@ -294,7 +294,7 @@ namespace Ray.Services
             saveData.Stats.TotalCurrency += DoubleAmount;
             LevelCurrency.Value *= 3;
 
-            await Database.Instance.Save(saveData);
+            await SaveService.Instance.Save(saveData);
 
             EventService.Resource.OnEndCurrencyChanged(this);
         }
@@ -308,7 +308,7 @@ namespace Ray.Services
             saveData.bightdData.RewardClaimed = true;
             saveData.Stats.TotalCurrency += Amount;
 
-            await Database.Instance.Save(saveData);
+            await SaveService.Instance.Save(saveData);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
         }
@@ -363,7 +363,7 @@ namespace Ray.Services
             saveData.Features.LastDailyGiftClaim = await TimeApiService.Instance.GetCurrentTime();
 
             BufferService.Instance.ReleaseBuffer();
-            await Database.Instance.Save(saveData);
+            await SaveService.Instance.Save(saveData);
             _rayDebug.Log($"Free gift claimed: +{giftAmount} coins!", this);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);

--- a/Scripts/MyCode/Services/SaveService.cs
+++ b/Scripts/MyCode/Services/SaveService.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Ray.Services
+{
+    public class SaveService : MonoBehaviour
+    {
+        public static SaveService Instance;
+
+        private readonly Queue<(UserData data, TaskCompletionSource<bool> tcs)> _saveQueue = new();
+        private bool _isProcessing = false;
+
+        private void Awake()
+        {
+            Instance = this;
+        }
+
+        public Task Save(UserData saveData)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            lock (_saveQueue)
+            {
+                _saveQueue.Enqueue((saveData, tcs));
+                if (!_isProcessing)
+                {
+                    _ = ProcessQueue();
+                }
+            }
+            return tcs.Task;
+        }
+
+        private async Task ProcessQueue()
+        {
+            _isProcessing = true;
+            while (true)
+            {
+                (UserData data, TaskCompletionSource<bool> tcs) item;
+                lock (_saveQueue)
+                {
+                    if (_saveQueue.Count == 0)
+                    {
+                        _isProcessing = false;
+                        return;
+                    }
+                    item = _saveQueue.Dequeue();
+                }
+                try
+                {
+                    await Database.Instance.Save(item.data);
+                    item.tcs.TrySetResult(true);
+                }
+                catch (Exception ex)
+                {
+                    item.tcs.TrySetException(ex);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SaveService` to queue and serialize all database writes
- Route resource, IAP, and user data updates through the new `SaveService`
- Replace direct `Database.Save` calls to prevent simultaneous writes

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b6a3e77fbc832da9c5a637396ecffc