### PR TITLE
Centralize save operations with queuing

### DIFF
--- a/Scripts/BrickBlast/Data/ResourceObject.cs
+++ b/Scripts/BrickBlast/Data/ResourceObject.cs
@@ -75,7 +75,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Data
                 {
                     var saveData = Database.UserData.Copy();
                     saveData.TotalCurrency += amount;
-                    await Database.Instance.Save(saveData);
+                    await Database.Instance.QueueSave(saveData);
                 }
             }
             else
@@ -95,7 +95,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Data
                 {
                     var saveData = Database.UserData.Copy();
                     saveData.TotalCurrency = amount;
-                    await Database.Instance.Save(saveData);
+                    await Database.Instance.QueueSave(saveData);
                 }
             }
             else
@@ -118,7 +118,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Data
                     {
                         var saveData = Database.UserData.Copy();
                         saveData.TotalCurrency -= amount;
-                        _ = Database.Instance.Save(saveData);
+                        Database.Instance.QueueSave(saveData);
                     }
                 }
                 else

--- a/Scripts/MyCode/Database/Database.cs
+++ b/Scripts/MyCode/Database/Database.cs
@@ -22,6 +22,8 @@ namespace Ray.Services
         private string _userID;
         public string UserId => _userID;
         private readonly SemaphoreSlim _saveSemaphore = new SemaphoreSlim(1, 1);
+        private Task _saveQueue = Task.CompletedTask;
+        private readonly object _saveQueueLock = new object();
 
         private RayDebugService _rayDebug => ServiceAllocator.Instance.GetDebugService(ConfigType.Services);
 
@@ -154,7 +156,7 @@ namespace Ray.Services
 
                     await MigrateLegacyProgress();
 
-                    await Save(UserData);
+                    await QueueSave(UserData);
                     _rayDebug.Log("User Data Loaded and Saved: " + JsonUtility.ToJson(UserData, true), this);
                 }
                 else
@@ -192,7 +194,7 @@ namespace Ray.Services
 
             if (changed)
             {
-                await Save(UserData);
+                await QueueSave(UserData);
             }
 
             PlayerPrefs.SetInt("MigratedToUserData", 1);
@@ -274,7 +276,16 @@ namespace Ray.Services
             }
         }
 
-        public async Task Save(UserData saveData)
+        public Task QueueSave(UserData saveData)
+        {
+            lock (_saveQueueLock)
+            {
+                _saveQueue = _saveQueue.ContinueWith(_ => Save(saveData)).Unwrap();
+                return _saveQueue;
+            }
+        }
+
+        private async Task Save(UserData saveData)
         {
             await _saveSemaphore.WaitAsync();
             try
@@ -446,7 +457,7 @@ namespace Ray.Services
             UserData.Stats.TotalCurrency++;
 
             var saveData = Database.UserData.Copy();
-            await Database.Instance.Save(saveData);
+            await QueueSave(saveData);
         }
 
         // Development

--- a/Scripts/MyCode/Database/UserData.cs
+++ b/Scripts/MyCode/Database/UserData.cs
@@ -98,7 +98,7 @@ public class UserData
     {
         var saveData = Database.UserData.Copy();
         saveData.TotalCurrency += amount;
-        await Database.Instance?.Save(saveData);
+        await Database.Instance?.QueueSave(saveData);
     }
 
     public async Task AddScoreAsCurrency(int score)
@@ -106,7 +106,7 @@ public class UserData
         var saveData = Database.UserData.Copy();
         saveData.Stats.TotalCurrency += score;
         saveData.Stats.TotalSessions++;
-        await Database.Instance?.Save(saveData);
+        await Database.Instance?.QueueSave(saveData);
     }
 
     public async Task<bool> SpendCurrency(int amount)
@@ -115,7 +115,7 @@ public class UserData
         {
             var saveData = Database.UserData.Copy();
             saveData.TotalCurrency -= amount;
-            await Database.Instance?.Save(saveData);
+            await Database.Instance?.QueueSave(saveData);
             return true;
         }
         return false;
@@ -143,7 +143,7 @@ public class UserData
 
         // Update the runtime copy immediately so subsequent code sees the new level
         Database.UserData = saveData;
-        Database.Instance?.Save(saveData);
+        Database.Instance?.QueueSave(saveData);
     }
 
     public void SetGroupIndex(int value)
@@ -159,6 +159,6 @@ public class UserData
 
         // Ensure local data reflects the new group before saving asynchronously
         Database.UserData = saveData;
-        Database.Instance?.Save(saveData);
+        Database.Instance?.QueueSave(saveData);
     }
 }

--- a/Scripts/MyCode/Services/IAPService.cs
+++ b/Scripts/MyCode/Services/IAPService.cs
@@ -301,7 +301,7 @@ namespace Ray.Services
                 bundleSave.Stats.Power_3 = Mathf.Clamp(bundleSave.Stats.Power_3 + bundle.Booster_Square, 0, 99);
                 bundleSave.Stats.Power_4 = Mathf.Clamp(bundleSave.Stats.Power_4 + bundle.Booster_Shape, 0, 99);
 
-                await Database.Instance.Save(bundleSave);
+                await Database.Instance.QueueSave(bundleSave);
 
                 EventService.IAP.HandlePurchasedConsumable(this);
                 EventService.Resource.OnMenuResourceChanged?.Invoke(this);
@@ -315,7 +315,7 @@ namespace Ray.Services
             var saveData = Database.UserData.Copy();
             saveData.Stats.TotalCurrency += rewardAmount;
 
-            await Database.Instance.Save(saveData);
+            await Database.Instance.QueueSave(saveData);
 
             EventService.IAP.HandlePurchasedConsumable(this);
 

--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -83,7 +83,7 @@ namespace Ray.Services
 
             saveData.Stats.Level += upgradeProp.LevelIncrement;
 
-            await Database.Instance.Save(saveData);
+            await Database.Instance.QueueSave(saveData);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
             RayBrickMediator.Instance?.RefreshShop(this);
@@ -163,7 +163,7 @@ namespace Ray.Services
 
             saveData.Stats.TotalCurrency -= cost;
 
-            await Database.Instance.Save(saveData);
+            await Database.Instance.QueueSave(saveData);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
             RayBrickMediator.Instance?.RefreshShop(this);
@@ -189,7 +189,7 @@ namespace Ray.Services
                     break;
             }
 
-            await Database.Instance.Save(saveData);
+            await Database.Instance.QueueSave(saveData);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
             RayBrickMediator.Instance?.RefreshShop(this);
@@ -215,7 +215,7 @@ namespace Ray.Services
                     break;
             }
 
-            await Database.Instance.Save(saveData);
+            await Database.Instance.QueueSave(saveData);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
             RayBrickMediator.Instance?.RefreshShop(this);
@@ -226,7 +226,7 @@ namespace Ray.Services
             _rayDebug.Event("RewardNoEnemies", c, this);
 
             var saveData = Database.UserData.Copy();
-            await Database.Instance.Save(saveData);
+            await Database.Instance.QueueSave(saveData);
 
             NoEnemies.Value = true;
 
@@ -298,7 +298,7 @@ namespace Ray.Services
             saveData.Stats.TotalCurrency += DoubleAmount;
             LevelCurrency.Value *= 3;
 
-            await Database.Instance.Save(saveData);
+            await Database.Instance.QueueSave(saveData);
 
             EventService.Resource.OnEndCurrencyChanged?.Invoke(this);
         }
@@ -312,7 +312,7 @@ namespace Ray.Services
             saveData.bightdData.RewardClaimed = true;
             saveData.Stats.TotalCurrency += Amount;
 
-            await Database.Instance.Save(saveData);
+            await Database.Instance.QueueSave(saveData);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
         }
@@ -367,7 +367,7 @@ namespace Ray.Services
             saveData.Features.LastDailyGiftClaim = await TimeApiService.Instance.GetCurrentTime();
 
             BufferService.Instance.ReleaseBuffer();
-            await Database.Instance.Save(saveData);
+            await Database.Instance.QueueSave(saveData);
             _rayDebug.Log($"Free gift claimed: +{giftAmount} coins!", this);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);


### PR DESCRIPTION
## Summary
- Add QueueSave in Database to serialize save requests
- Route all user-data updates through Database.QueueSave
- Remove direct Save usage across services and data objects

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b6a5079e40832d9fee6e209f0ca77a