### PR TITLE
Fix buffer save scheduler

### DIFF
--- a/Scripts/MyCode/Database/Database.cs
+++ b/Scripts/MyCode/Database/Database.cs
@@ -287,8 +287,6 @@ namespace Ray.Services
                         TaskScheduler.FromCurrentSynchronizationContext())
                     .Unwrap();
 
-                _saveQueue = _saveQueue.ContinueWith(_ => Save(saveData)).Unwrap();
-
                 return _saveQueue;
             }
         }


### PR DESCRIPTION
## Summary
- ensure database save operations run on the Unity main thread by removing extraneous continuation that could execute on a worker thread

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b6a96f1df4832db78fa28008cbe6b5