### PR TITLE
Fix final score display on end-game screens

### DIFF
--- a/Scripts/BrickBlast/Popups/FailedScore.cs
+++ b/Scripts/BrickBlast/Popups/FailedScore.cs
@@ -12,6 +12,7 @@
 
 using BlockPuzzleGameToolkit.Scripts.GUI;
 using BlockPuzzleGameToolkit.Scripts.GUI.Labels;
+using BlockPuzzleGameToolkit.Scripts.Gameplay;
 using UnityEngine;
 
 namespace BlockPuzzleGameToolkit.Scripts.Popups
@@ -22,10 +23,22 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
 
         private void Start()
         {
+            var modeHandler = FindObjectOfType<BaseModeHandler>(true);
+
             var scoreLabel = FindObjectOfType<TargetsUIHandler>().ScoreLabel;
-            scoreLabel.GetComponent<TargetScoreGUIElement>().enabled = false;
+            var labelComponent = scoreLabel.GetComponent<TargetScoreGUIElement>();
+            labelComponent.enabled = false;
+
             var scoreObject = Instantiate(scoreLabel, transform);
             scoreObject.transform.position = scorePosition.position;
+
+            var scoreComponent = scoreObject.GetComponent<TargetScoreGUIElement>();
+            if (modeHandler != null && scoreComponent != null)
+            {
+                scoreComponent.countText.text = modeHandler.score.ToString();
+                scoreComponent.scoreSlider.maxValue = Mathf.Max(scoreComponent.scoreSlider.maxValue, modeHandler.score);
+                scoreComponent.scoreSlider.value = modeHandler.score;
+            }
         }
     }
 }

--- a/Scripts/BrickBlast/Popups/PreWinScore.cs
+++ b/Scripts/BrickBlast/Popups/PreWinScore.cs
@@ -12,7 +12,6 @@
 
 using BlockPuzzleGameToolkit.Scripts.Gameplay;
 using BlockPuzzleGameToolkit.Scripts.GUI.Labels;
-using BlockPuzzleGameToolkit.Scripts.LevelsData;
 using UnityEngine;
 using System.Collections;
 
@@ -20,26 +19,21 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
 {
     public class PreWinScore : PreWin
     {
-        public TargetScriptable scoreTarget;
         public TargetScoreGUIElement scoreSlider;
         private bool animationCompleted = false;
 
         protected override void OnEnable()
         {
             base.OnEnable();
-            var targetManager = FindObjectOfType<TargetManager>();
 
-            if (!targetManager.GetTargetGuiElements().TryGetValue(scoreTarget, out var targetGuiElement))
+            var modeHandler = FindObjectOfType<BaseModeHandler>(true);
+            if (modeHandler == null)
             {
                 scoreSlider.UpdateCount(0, false);
                 return;
             }
 
-            // Get the final score value
-            if (!int.TryParse(targetGuiElement.countText.text, out int finalScore))
-            {
-                return;
-            }
+            int finalScore = modeHandler.score;
 
             // Set up the total score and animate
             scoreSlider.totalText.text = finalScore.ToString();
@@ -54,12 +48,12 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
         private IEnumerator AnimateWithDelay(int finalScore)
         {
             yield return new WaitForSeconds(.3f);
-            
+
             scoreSlider.UpdateCount(finalScore, true);
-            
+
             float startTime = Time.time;
             float elapsedTime = 0f;
-            
+
             // Wait until the slider animation is complete or timeout
             while (Mathf.Abs(scoreSlider.scoreSlider.value - finalScore) > 0.01f && elapsedTime < scoreSlider.duration * 1.5f)
             {
@@ -72,7 +66,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
             {
                 scoreSlider.scoreSlider.value = finalScore;
             }
-            
+
             animationCompleted = true;
             yield return new WaitForSeconds(.1f);
             base.AfterShowAnimation();

--- a/Scripts/BrickBlast/Popups/WinScore.cs
+++ b/Scripts/BrickBlast/Popups/WinScore.cs
@@ -11,7 +11,6 @@
 // // THE SOFTWARE.
 
 using BlockPuzzleGameToolkit.Scripts.Gameplay;
-using BlockPuzzleGameToolkit.Scripts.LevelsData;
 using TMPro;
 
 namespace BlockPuzzleGameToolkit.Scripts.Popups
@@ -19,14 +18,11 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
     public class WinScore : Win
     {
         public TextMeshProUGUI scoreText;
-        public TargetScriptable scoreTarget;
 
         private void Start()
         {
-            var targetManager = FindObjectOfType<TargetManager>();
-            scoreText.text = targetManager.GetTargetGuiElements().TryGetValue(scoreTarget, out var targetGuiElement)
-                ? targetGuiElement.countText.text
-                : "0";
+            var modeHandler = FindObjectOfType<BaseModeHandler>(true);
+            scoreText.text = modeHandler != null ? modeHandler.score.ToString() : "0";
         }
     }
 }


### PR DESCRIPTION
## Summary
- Ensure win popup displays the player's final score using the active mode handler
- Animate pre-win score slider based on the recorded final score
- Show the correct score on failure popup by cloning the score label and populating it from the mode handler

## Testing
- `dotnet test` *(fails: command not found)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b6b05bf59c832d9a332df7e246f1ab