### PR TITLE
Clear lingering outline effects when disabling HighlightManager

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/HighlightManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/HighlightManager.cs
@@ -55,6 +55,10 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
         private void OnDisable()
         {
             EventManager.GetEvent<Shape>(EGameEvent.ShapePlaced).Unsubscribe(OnShapePlaced);
+
+            // Ensure any active outlines or highlight particles are cleaned up
+            // when the manager is disabled (e.g. when switching stages).
+            ClearAllHighlights();
         }
 
         private void OnShapePlaced(Shape obj)


### PR DESCRIPTION
## Summary
- Clear all highlights when `HighlightManager` is disabled to prevent outline particles from sticking to the screen when switching stages or similar state changes

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b6d2fc2a18832d959c0725caa67b67