### PR TITLE
Accumulate arcade mode scores across level group

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/LevelManager.cs
@@ -575,8 +575,6 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
                 ResourceService.Instance?.SubmitLevelScore(modeHandler.score);
             }
 
-            EventService.Player.OnParked?.Invoke(this);
-
             // Calculate the next stage using absolute level numbering to avoid
             // resetting to the first level when progressing within a group.
             int absoluteLevel = (Database.UserData.Stats.GroupIndex - 1) * 3 + Database.UserData.Stats.Level;
@@ -598,6 +596,9 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             }
             else
             {
+                // At the end of the third level, reward the player and show the end screen
+                EventService.Player.OnParked?.Invoke(this);
+
                 GameDataManager.UnlockGroup(currentGroup + 1);
                 GameDataManager.ResetSubLevelIndex();
 

--- a/Scripts/BrickBlast/Popups/WinScore.cs
+++ b/Scripts/BrickBlast/Popups/WinScore.cs
@@ -12,9 +12,8 @@
 
 
 using BlockPuzzleGameToolkit.Scripts.System;
-
 using BlockPuzzleGameToolkit.Scripts.Gameplay;
-
+using Ray.Services;
 using TMPro;
 
 namespace BlockPuzzleGameToolkit.Scripts.Popups
@@ -25,11 +24,11 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
 
         private void Start()
         {
-            scoreText.text = GameManager.instance.LastScore.ToString();
+            int currency = ResourceService.Instance != null
+                ? ResourceService.Instance.LevelCurrency.Value
+                : GameManager.instance.LastScore;
 
-            var modeHandler = FindObjectOfType<BaseModeHandler>(true);
-            scoreText.text = modeHandler != null ? modeHandler.score.ToString() : "0";
-
+            scoreText.text = currency.ToString();
         }
     }
 }

--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using UnityEngine;
+using BlockPuzzleGameToolkit.Scripts.System;
 
 namespace Ray.Services
 {
@@ -237,13 +238,22 @@ namespace Ray.Services
         {
             _rayDebug.Event("ResetLevelResources", c, this);
 
-            LevelCurrency.Value = 0;
-            LevelScore.Value = 0;
+            // Only reset earnings at the start of a new stage. During
+            // intermediate levels, keep accumulated values so they can be
+            // rewarded together at the end of the three-level group.
+            if (GameDataManager.GetSubLevelIndex() == 1)
+            {
+                LevelCurrency.Value = 0;
+                LevelScore.Value = 0;
+
+                // Notify listeners that resources were reset so UI and score
+                // handlers can update accordingly.
+                EventService.Resource.OnEndCurrencyChanged.Invoke(this);
+            }
 
             LevelSpace.Value = Database.UserData.Stats.Level;
 
             EventService.Resource.OnLevelResourceChanged.Invoke(this);
-            EventService.Resource.OnEndCurrencyChanged.Invoke(this);
         }
 
         private void ProcessItemValueUsingY(Component c, ItemType itemType, Vector2 itemPos)


### PR DESCRIPTION
## Summary
- preserve running currency and score until end of a three-level arcade stage
- only finalize and reward score after the third level
- ensure win screen displays accumulated currency instead of zero

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b6d4243b58832d95ca2af94bc13c12