### PR TITLE
Refactor stage rewards

### DIFF
--- a/Scripts/BrickBlast/Popups/Failed.cs
+++ b/Scripts/BrickBlast/Popups/Failed.cs
@@ -41,7 +41,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
 
             if (currencyText != null)
             {
-                currencyText.text = GameManager.instance.LastScore.ToString();
+                currencyText.text = RayBrickMediator.Instance?.CalculateStageCurrency().ToString();
             }
 
             if (tripleRewardButton != null)
@@ -75,7 +75,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
             rewardGranted = true;
             StopInteration();
 
-            await Database.UserData.AddScoreAsCurrency(GameManager.instance.LastScore);
+            await Database.UserData.AddCurrency(RayBrickMediator.Instance.CalculateStageCurrency());
             GameManager.instance.RestartLevel();
             Close();
         }
@@ -86,7 +86,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
             rewardGranted = true;
             StopInteration();
 
-            await Database.UserData.AddScoreAsCurrency(GameManager.instance.LastScore);
+            await Database.UserData.AddCurrency(RayBrickMediator.Instance.CalculateStageCurrency());
             GameManager.instance.MainMenu();
             Close();
         }
@@ -105,7 +105,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
             if (rewardGranted) return;
             rewardGranted = true;
 
-            await Database.UserData.AddScoreAsCurrency(GameManager.instance.LastScore * 3);
+            await Database.UserData.AddCurrency(RayBrickMediator.Instance.CalculateStageCurrency() * 3);
             GameManager.instance.MainMenu();
             Close();
         }

--- a/Scripts/BrickBlast/Popups/FailedClassic.cs
+++ b/Scripts/BrickBlast/Popups/FailedClassic.cs
@@ -30,7 +30,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
         {
             base.OnEnable();
             modeHandler = FindObjectOfType<BaseModeHandler>(false);
-            var score = GameManager.instance.LastScore;
+            var score = RayBrickMediator.Instance?.CalculateStageCurrency() ?? 0;
             var bestScore = modeHandler != null ? modeHandler.bestScore : 0;
             scoreText[0].text = score.ToString();
             scoreText[1].text = score.ToString();

--- a/Scripts/BrickBlast/Popups/FailedScore.cs
+++ b/Scripts/BrickBlast/Popups/FailedScore.cs
@@ -27,8 +27,6 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
 
         private void Start()
         {
-            var modeHandler = FindObjectOfType<BaseModeHandler>(true);
-
             var scoreLabel = FindObjectOfType<TargetsUIHandler>().ScoreLabel;
             var labelComponent = scoreLabel.GetComponent<TargetScoreGUIElement>();
             labelComponent.enabled = false;
@@ -40,19 +38,10 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
 
             if (scoreComponent != null)
             {
-                int finalScore = GameManager.instance.LastScore;
+                int finalScore = RayBrickMediator.Instance?.CalculateStageCurrency() ?? 0;
                 scoreComponent.countText.text = finalScore.ToString();
                 scoreComponent.scoreSlider.maxValue = Mathf.Max(scoreComponent.scoreSlider.maxValue, finalScore);
                 scoreComponent.scoreSlider.value = finalScore;
-
-                if (modeHandler != null && scoreComponent != null)
-                {
-                    scoreComponent.countText.text = modeHandler.score.ToString();
-                    scoreComponent.scoreSlider.maxValue =
-                        Mathf.Max(scoreComponent.scoreSlider.maxValue, modeHandler.score);
-                    scoreComponent.scoreSlider.value = modeHandler.score;
-
-                }
             }
         }
     }

--- a/Scripts/BrickBlast/Popups/PreFailed.cs
+++ b/Scripts/BrickBlast/Popups/PreFailed.cs
@@ -29,6 +29,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
         public Button continueButton;
         public Button reviveButton;
         public TextMeshProUGUI timeLeftText;
+        public TextMeshProUGUI currencyText;
         protected int timer;
         protected int price;
         protected bool hasContinued = false;
@@ -49,6 +50,10 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
             if (timerText != null)
             {
                 timerText.text = timer.ToString();
+            }
+            if (currencyText != null)
+            {
+                currencyText.text = RayBrickMediator.Instance?.CalculateStageCurrency().ToString();
             }
             SoundBase.instance.PlaySound(SoundBase.instance.warningTime);
             InvokeRepeating(nameof(UpdateTimer), 1, 1);
@@ -129,7 +134,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
         private async void ContinueGame()
         {
             result = EPopupResult.Continue;
-            await Database.UserData.AddScoreAsCurrency(GameManager.instance.LastScore);
+            await Database.UserData.AddCurrency(RayBrickMediator.Instance.CalculateStageCurrency());
 
             // Restart from the first level within the current group
             Database.UserData.SetLevel(1);

--- a/Scripts/BrickBlast/Popups/PreWinScore.cs
+++ b/Scripts/BrickBlast/Popups/PreWinScore.cs
@@ -29,18 +29,8 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
         {
             base.OnEnable();
 
-            int finalScore = GameManager.instance.LastScore;
+            int finalScore = RayBrickMediator.Instance?.CalculateStageCurrency() ?? 0;
 
-            var modeHandler = FindObjectOfType<BaseModeHandler>(true);
-            if (modeHandler == null)
-            {
-                scoreSlider.UpdateCount(0, false);
-                return;
-            }
-
-            finalScore = modeHandler.score;
-
-            // Set up the total score and animate
             scoreSlider.totalText.text = finalScore.ToString();
             scoreSlider.scoreSlider.maxValue = finalScore;
             scoreSlider.scoreSlider.value = 0;

--- a/Scripts/BrickBlast/Popups/WinScore.cs
+++ b/Scripts/BrickBlast/Popups/WinScore.cs
@@ -26,7 +26,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
         {
             int currency = ResourceService.Instance != null
                 ? ResourceService.Instance.LevelCurrency.Value
-                : GameManager.instance.LastScore;
+                : RayBrickMediator.Instance?.CalculateStageCurrency() ?? 0;
 
             scoreText.text = currency.ToString();
         }

--- a/Scripts/BrickBlast/RayBrickMediator.cs
+++ b/Scripts/BrickBlast/RayBrickMediator.cs
@@ -187,6 +187,11 @@ using System.Collections.Generic;
             RewardedService.Instance.ShowRewarded(RewardedType.Revive);
         }
 
+        public int CalculateStageCurrency()
+        {
+            return 5;
+        }
+
         public void SetWinButtons(Button collectButton, Button tripleButton, TextMeshProUGUI currencyText)
         {
             // Remove previous listeners if any
@@ -201,7 +206,7 @@ using System.Collections.Generic;
             winRewardGranted = false;
 
             if (winCurrencyText != null)
-                winCurrencyText.text = GameManager.instance.LastScore.ToString();
+                winCurrencyText.text = CalculateStageCurrency().ToString();
 
             if (winCollectButton != null)
                 winCollectButton.onClick.AddListener(OnWinCollectClicked);
@@ -221,7 +226,7 @@ using System.Collections.Generic;
             var popup = MenuManager.instance.GetLastPopup() as Popup;
             popup?.StopInteration();
 
-            await Database.UserData.AddScoreAsCurrency(GameManager.instance.LastScore);
+            await Database.UserData.AddCurrency(CalculateStageCurrency());
             GameManager.instance.NextLevel();
             popup?.Close();
         }
@@ -243,7 +248,7 @@ using System.Collections.Generic;
             var popup = MenuManager.instance.GetLastPopup() as Popup;
             popup?.StopInteration();
 
-            await Database.UserData.AddScoreAsCurrency(GameManager.instance.LastScore * 3);
+            await Database.UserData.AddCurrency(CalculateStageCurrency() * 3);
             GameManager.instance.NextLevel();
             popup?.Close();
         }

--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -287,14 +287,11 @@ namespace Ray.Services
         {
             _rayDebug.Event("RewardEndCurrency", c, this);
 
-            // Combine any transient level earnings with collected currency
-            int total = LevelCurrency.Value + LevelScore.Value;
-
-            LevelCurrency.Value = total;
-
+            int reward = RayBrickMediator.Instance?.CalculateStageCurrency() ?? 0;
+            LevelCurrency.Value = reward;
             if (Database.UserData != null)
             {
-                await Database.UserData.AddScoreAsCurrency(total);
+                await Database.UserData.AddCurrency(reward);
             }
             LevelScore.Value = 0;
 
@@ -305,11 +302,11 @@ namespace Ray.Services
         {
             _rayDebug.Event("RewardEndTriple", c, this);
 
-            int DoubleAmount = LevelCurrency.Value * 2;
+            int reward = (RayBrickMediator.Instance?.CalculateStageCurrency() ?? 0) * 3;
 
             var saveData = Database.UserData.Copy();
-            saveData.Stats.TotalCurrency += DoubleAmount;
-            LevelCurrency.Value *= 3;
+            saveData.Stats.TotalCurrency += reward;
+            LevelCurrency.Value = reward;
 
             await Database.Instance.QueueSave(saveData);
 


### PR DESCRIPTION
## Summary
- compute fixed stage currency via `RayBrickMediator.CalculateStageCurrency`
- grant end-of-stage currency using this formula instead of score
- update win/fail/pre-win/pre-failed screens to display awarded currency

## Testing
- ⚠️ `dotnet test` (command not found)
- ✅ `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b6db30ae28832daa0b5a7e3ef97e01