### PR TITLE
Prevent NRE when recording booster button colors

### DIFF
--- a/Scripts/BrickBlast/Gameplay/Managers/BoosterManager.cs
+++ b/Scripts/BrickBlast/Gameplay/Managers/BoosterManager.cs
@@ -62,7 +62,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Gameplay
             boosterButtons = new[] { rowButton, columnButton, squareButton, changeShapeButton };
             foreach (var btn in boosterButtons)
             {
-                if (btn != null)
+                if (btn != null && btn.image != null)
                     originalButtonColors[btn] = btn.image.color;
             }
 


### PR DESCRIPTION
## Summary
- Avoid accessing `Button.image` when it is missing in `BoosterManager`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b6f0776eec832da0214c0a3414e21f