### PR TITLE
Avoid buffer when using boosters

### DIFF
--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -222,13 +222,10 @@ namespace Ray.Services
             }
 
             // Apply the change locally so text updates immediately instead of after the next use
-
-            
-            await Database.Instance.QueueSave(saveData);
-
             Database.UserData = saveData;
-            await Database.Instance.QueueSave(saveData, false);
 
+            // Save without showing the buffer screen
+            await Database.Instance.QueueSave(saveData, false);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
             RayBrickMediator.Instance?.RefreshShop(this);


### PR DESCRIPTION
## Summary
- Prevent buffer overlay when consuming boosters by saving without BufferService and updating local user data first.

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b6f1acc0cc832db9b6da3d6e230884