### PR TITLE
Show interstitial ads before game end screens

### DIFF
--- a/Ads/InterstitialService.cs
+++ b/Ads/InterstitialService.cs
@@ -36,7 +36,7 @@ namespace Ray.Controllers
             MaxSdk.LoadInterstitial(Database.GameSettings.Advertising.Interstitial.Penalty);
         }
 
-        private void TryShowInter(Component c)
+        public void TryShowInter(Component c)
         {
             _rayDebug.Event("TryShowInter", c, this);
 

--- a/Scripts/BrickBlast/LevelsData/LevelStateHandler.cs
+++ b/Scripts/BrickBlast/LevelsData/LevelStateHandler.cs
@@ -3,6 +3,7 @@ using BlockPuzzleGameToolkit.Scripts.Enums;
 using BlockPuzzleGameToolkit.Scripts.Gameplay;
 using BlockPuzzleGameToolkit.Scripts.System;
 using BlockPuzzleGameToolkit.Scripts.Popups;
+using Ray.Controllers;
 
 namespace BlockPuzzleGameToolkit.Scripts.LevelsData
 {
@@ -54,6 +55,7 @@ namespace BlockPuzzleGameToolkit.Scripts.LevelsData
 
         private protected virtual void HandleFailed(LevelManager levelManager)
         {
+            InterstitialService.Instance?.TryShowInter(levelManager);
             var failedPopup = levelManager.GetCurrentLevel().levelType.failedPopup;
             if (failedPopup != null)
             {
@@ -83,6 +85,7 @@ namespace BlockPuzzleGameToolkit.Scripts.LevelsData
 
         private protected virtual void HandleWin(LevelManager levelManager)
         {
+            InterstitialService.Instance?.TryShowInter(levelManager);
             var winPopup = levelManager.GetCurrentLevel().levelType.winPopup
                 ?? RayBrickMediator.Instance?.WinPopup;
 


### PR DESCRIPTION
## Summary
- expose interstitial ad counter so other systems can trigger it
- trigger interstitial ads before displaying fail or win popups across all game modes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 from repository)*

------
https://chatgpt.com/codex/tasks/task_b_68b6f4109c50832d8f064b2a1cdeb0e4