### PR TITLE
Ensure user level resets on menu entry

### DIFF
--- a/Scripts/BrickBlast/Popups/MainMenu.cs
+++ b/Scripts/BrickBlast/Popups/MainMenu.cs
@@ -15,6 +15,7 @@ using BlockPuzzleGameToolkit.Scripts.Enums;
 using BlockPuzzleGameToolkit.Scripts.GUI;
 using BlockPuzzleGameToolkit.Scripts.LevelsData;
 using BlockPuzzleGameToolkit.Scripts.System;
+using Ray.Services;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -41,6 +42,10 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
 
         private void Start()
         {
+            // Ensure the player's level is reset whenever the main menu is shown
+            // This covers both the initial game launch and any return to the menu
+            Database.UserData.SetLevel(1);
+
             timedMode.onClick.AddListener(PlayTimedMode);
             classicMode.onClick.AddListener(PlayClassicMode);
             adventureMode.onClick.AddListener(PlayAdventureMode);

--- a/Scripts/BrickBlast/System/GameManager.cs
+++ b/Scripts/BrickBlast/System/GameManager.cs
@@ -137,6 +137,10 @@ namespace BlockPuzzleGameToolkit.Scripts.System
 
         public void MainMenu()
         {
+            // Reset the player's level whenever navigating back to the main menu
+            // This ensures a fresh state regardless of how the menu is reached
+            Database.UserData.SetLevel(1);
+
             DOTween.KillAll();
             if (StateManager.instance.CurrentState == EScreenStates.Game && GameDataManager.GetGameMode() == EGameMode.Classic)
             {


### PR DESCRIPTION
## Summary
- Reset user level to 1 whenever the main menu opens
- Ensure navigating back to main menu sets user level to 1

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b6f9fcb44c832d96cb57dc8b79c0b2