### PR TITLE
Reset stage group on retry

### DIFF
--- a/Scripts/BrickBlast/Popups/Failed.cs
+++ b/Scripts/BrickBlast/Popups/Failed.cs
@@ -76,6 +76,11 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
             StopInteration();
 
             await Database.UserData.AddCurrency(RayBrickMediator.Instance.CalculateStageCurrency());
+            // Restart from the first level within the current group
+            Database.UserData.SetLevel(1);
+            GameDataManager.ResetSubLevelIndex();
+            GameDataManager.SetLevel(null);
+
             GameManager.instance.RestartLevel();
             Close();
         }


### PR DESCRIPTION
## Summary
- Restart failed stage group from level 1 when pressing Retry

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b7f869ac60832daa2803258c39f5a2