### PR TITLE
Allow async saves without displaying buffer

### DIFF
--- a/Scripts/MyCode/Database/Database.cs
+++ b/Scripts/MyCode/Database/Database.cs
@@ -276,13 +276,13 @@ namespace Ray.Services
             }
         }
 
-        public Task QueueSave(UserData saveData)
+        public Task QueueSave(UserData saveData, bool showBuffer = true)
         {
             lock (_saveQueueLock)
             {
 
                 _saveQueue = _saveQueue
-                    .ContinueWith(_ => Save(saveData), CancellationToken.None,
+                    .ContinueWith(_ => Save(saveData, showBuffer), CancellationToken.None,
                         TaskContinuationOptions.None,
                         TaskScheduler.FromCurrentSynchronizationContext())
                     .Unwrap();
@@ -291,12 +291,12 @@ namespace Ray.Services
             }
         }
 
-        private async Task Save(UserData saveData)
+        private async Task Save(UserData saveData, bool showBuffer = true)
         {
             await _saveSemaphore.WaitAsync();
             try
             {
-                BufferService.Instance.RequestBuffer();
+                if (showBuffer) BufferService.Instance.RequestBuffer();
 
                 var userDoc = _firestore.Collection("UserData").Document(_userID);
                 DocumentSnapshot serverSnapshot = await userDoc.GetSnapshotAsync();
@@ -386,7 +386,7 @@ namespace Ray.Services
             }
             finally
             {
-                BufferService.Instance.ReleaseBuffer();
+                if (showBuffer) BufferService.Instance.ReleaseBuffer();
                 _saveSemaphore.Release();
             }
         }

--- a/Scripts/MyCode/Services/ResourceService.cs
+++ b/Scripts/MyCode/Services/ResourceService.cs
@@ -219,7 +219,7 @@ namespace Ray.Services
                     break;
             }
 
-            await Database.Instance.QueueSave(saveData);
+            await Database.Instance.QueueSave(saveData, showBuffer:false);
 
             EventService.Resource.OnMenuResourceChanged.Invoke(this);
             RayBrickMediator.Instance?.RefreshShop(this);


### PR DESCRIPTION
## Summary
- Add optional `showBuffer` flag to `Database.QueueSave`/`Save` and guard buffer requests
- Use `QueueSave(saveData, showBuffer:false)` in `ResourceService.ConsumeBooster` to save without UI buffering

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b7fc88c7b8832d83f02e28c03e0b43