### PR TITLE
Ensure failed continue buttons return to main menu

### DIFF
--- a/Scripts/BrickBlast/Popups/Failed.cs
+++ b/Scripts/BrickBlast/Popups/Failed.cs
@@ -36,7 +36,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
 
             if (closeButton != null)
             {
-                closeButton.onClick.AddListener(CollectAndExit);
+                closeButton.onClick.AddListener(Continue);
             }
 
             if (currencyText != null)
@@ -60,7 +60,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
 
             if (closeButton != null)
             {
-                closeButton.onClick.RemoveListener(CollectAndExit);
+                closeButton.onClick.RemoveListener(Continue);
             }
 
             if (tripleRewardButton != null)
@@ -85,7 +85,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
             Close();
         }
 
-        private async void CollectAndExit()
+        private async void Continue()
         {
             if (rewardGranted) return;
             rewardGranted = true;

--- a/Scripts/BrickBlast/Popups/PreFailed.cs
+++ b/Scripts/BrickBlast/Popups/PreFailed.cs
@@ -136,12 +136,7 @@ namespace BlockPuzzleGameToolkit.Scripts.Popups
             result = EPopupResult.Continue;
             await Database.UserData.AddCurrency(RayBrickMediator.Instance.CalculateStageCurrency());
 
-            // Restart from the first level within the current group
-            Database.UserData.SetLevel(1);
-            GameDataManager.ResetSubLevelIndex();
-            GameDataManager.SetLevel(null);
-
-            GameManager.instance.RestartLevel();
+            GameManager.instance.MainMenu();
             Close();
         }
     }


### PR DESCRIPTION
## Summary
- Add dedicated Continue method on failed popup that sends players to the Main Menu
- Restore original Retry logic so retry buttons restart the level
- Continue buttons on failure screens now route to the Main Menu instead of restarting

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b8027ecfbc832d87af916ce3cafb2b